### PR TITLE
Correct weights change with "nngt" backend

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -39,7 +39,7 @@ before_install:
         sudo apt-key adv --keyserver keys.openpgp.org --recv-key 612DEFB798507F25;
       fi
     # update package repository status (-qq is more quiet)
-    - sudo add-apt-repository -y ppa:nest-simulator/nest
+    # - sudo add-apt-repository -y ppa:nest-simulator/nest
     - sudo rm -rf /var/lib/apt/lists/*
     - ls /etc/apt/sources.list.d/
     - sudo apt-get update -qq

--- a/.travis.yml
+++ b/.travis.yml
@@ -34,8 +34,7 @@ cache:
 
 before_install:
     - if [[ "$GL" == "gt" ]]; then
-        sudo sh -c 'echo -n "deb http://downloads.skewed.de/apt/bionic bionic universe\n" >> /etc/apt/sources.list';
-        sudo sh -c 'echo -n "deb-src http://downloads.skewed.de/apt/bionic bionic universe\n" >> /etc/apt/sources.list';
+        sudo sh -c 'echo -n "deb http://downloads.skewed.de/apt bionic main\n" >> /etc/apt/sources.list';
         sudo apt-key adv --keyserver keys.openpgp.org --recv-key 612DEFB798507F25;
       fi
     # update package repository status (-qq is more quiet)

--- a/nngt/lib/graph_backends.py
+++ b/nngt/lib/graph_backends.py
@@ -328,25 +328,29 @@ def _set_nngt():
     nngt._config["backend"] = "nngt"
     nngt._config["library"] = nngt
     nngt._config["graph"]   = object
+
     # analysis functions
     def _notimplemented(*args, **kwargs):
         raise NotImplementedError("Install a graph library to use.")
+
     def adj_mat(graph, weight=None):
-        if weight in graph.edges_attributes and weight != "weight":
-            edges     = graph.edges_array
-            prop      = graph.get_edge_attributes(name=weight)
-            num_nodes = graph.node_nb()
-            mat       = ssp.coo_matrix((prop, (edges[:, 0], edges[:, 1])),
-                                       shape=(num_nodes, num_nodes))
-            return mat.tocsr()
-        elif weight is False:
-            mat = graph._adj_mat.tocsr()
-            mat.data = np.ones(len(mat.data))
-            return mat
+        data = None
+
+        if weight in graph.edges_attributes:
+            data = graph.get_edge_attributes(name=weight)
         else:
-            return graph._adj_mat.tocsr()
+            data = np.ones(graph.edge_nb())
+            
+        edges     = graph.edges_array
+        num_nodes = graph.node_nb()
+        mat       = ssp.coo_matrix((data, (edges[:, 0], edges[:, 1])),
+                                   shape=(num_nodes, num_nodes))
+
+        return mat.tocsr()
+
     def get_edges(graph):
         return graph.edges_array()
+
     # store functions
     nngt.analyze_graph["assortativity"] = _notimplemented
     nngt.analyze_graph["diameter"] = _notimplemented

--- a/testing/test_weights.py
+++ b/testing/test_weights.py
@@ -1,0 +1,84 @@
+#!/usr/bin/env python
+#-*- coding:utf-8 -*-
+
+# test_weights.py
+
+"""
+Test weights setting.
+"""
+
+import numpy as np
+
+import nngt
+import nngt.generation as ng
+
+
+def test_set_weights():
+    w = 10.
+    g = ng.erdos_renyi(nodes=100, density=0.1, weights=w)
+
+    assert set(g.get_weights()) == {w}
+
+    w2 = 5.
+    g.set_weights(w2)
+    
+    assert set(g.get_weights()) == {w2}
+
+    elist = g.get_edges()[:10]  # keep 10 first edges
+
+    w3 = 2.
+    g.set_weights(w3, elist=elist)
+
+    assert set(g.get_weights()) == {w2, w3}
+    assert set(g.get_weights(edges=elist)) == {w3}
+
+
+def test_weighted_degrees():
+    g = nngt.Graph()
+    g.new_node(10)
+
+    ww = [5.]*4
+    g.new_edges([(0, 4), (8, 2), (7, 0), (1, 3)], attributes={"weight": ww})
+
+    # check degrees
+    in_deg  = [1., 0., 1., 1., 1., 0., 0., 0., 0., 0.]
+    out_deg = [1., 1., 0., 0., 0., 0., 0., 1., 1., 0.]
+    tot_deg = [2., 1., 1., 1., 1., 0., 0., 1., 1., 0.]
+
+    assert np.all(g.get_degrees("in") == in_deg)
+    assert np.all(
+        g.get_degrees("in", use_weights=True) == np.multiply(ww[0], in_deg))
+    assert np.all(g.get_degrees("out") == out_deg)
+    assert np.all(g.get_degrees("total") == tot_deg)
+
+    # set all weights to zero
+    g.set_weights(0.)
+
+    assert set(g.get_weights()) == {0.}
+    assert set(g.get_edge_attributes(name="weight")) == {0.}
+
+    assert not np.any(g.get_degrees("in", use_weights=True))
+
+    # set two edges to 2.
+    elist = [(0, 4), (8, 2)]
+    g.set_weights(2., elist=elist)
+
+    assert set(g.get_weights()) == {0., 2.}
+    assert set(g.get_edge_attributes(name="weight")) == {0., 2.}
+
+    # test new weighted degree
+    w_indeg  = [0., 0., 2., 0., 2., 0., 0., 0., 0., 0.]
+    w_outdeg = [2., 0., 0., 0., 0., 0., 0., 0., 2., 0.]
+
+    assert np.all(g.get_degrees("in", use_weights=True) == w_indeg)
+
+    assert np.all(g.get_degrees("out", use_weights=True) == w_outdeg)
+
+    # check the node and edges
+    assert g.node_nb() == 10
+    assert g.edge_nb() == 4
+
+
+if __name__ == "__main__":
+    test_set_weights()
+    test_weighted_degrees()


### PR DESCRIPTION
This PR corrects an issue with weight changes in the default "nngt" backend.
It also remove the unnecessary storage of the adjacency matrix to keep only the edge list.