### PR TITLE
Full compatibility of backend support, including analysis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,6 +26,7 @@ jobs:
         - env: GL="ig"
         - env: GL="nx"
         - env: GL="nngt"
+        - env: GL="all"
     fast_finish: true
 
 cache:
@@ -33,7 +34,7 @@ cache:
     - pip
 
 before_install:
-    - if [[ "$GL" == "gt" ]]; then
+    - if [[ "$GL" == "gt" || "$GL" == "all" ]]; then
         sudo sh -c 'echo -n "deb http://downloads.skewed.de/apt bionic main\n" >> /etc/apt/sources.list';
         sudo apt-key adv --keyserver keys.openpgp.org --recv-key 612DEFB798507F25;
       fi
@@ -46,12 +47,14 @@ before_install:
     - sudo apt-get autoremove
     # requirements for building + installing scipy and igraph
     - sudo apt-get install -y build-essential autoconf automake libtool python-all-dev libblas-dev liblapack-dev libatlas-base-dev gfortran libxml2-dev openmpi-bin libopenmpi-dev libgmp-dev
-    - if [[ "$GL" == "ig" ]]; then sudo apt-get install -y libigraph0v5 libigraph0-dev; fi
+    - if [[ "$GL" == "ig" || "$GL" == "all" ]]; then
+        sudo apt-get install -y libigraph0v5 libigraph0-dev;
+      fi
     # install nest (segfaulting)
     # - apt install -y nest
     # setup pip, libraries, and aliases for graph-tool
     - shopt -s expand_aliases
-    - if [[ "$GL" == "gt" ]]; then
+    - if [[ "$GL" == "gt" || "$GL" == "all" ]]; then
         sudo apt-get install -y python3-pip python3-matplotlib python3-tk;
         alias pip3='sudo -H pip3';
       fi    
@@ -61,16 +64,26 @@ before_install:
     - pip3 install --upgrade cython
     - pip3 install --upgrade numpy scipy matplotlib shapely numpy mpi4py svg.path dxfgrabber pathlib pytest pytest-mpi cov-core coverage coveralls
     # install graph-tool, igraph, and networkx
-    - if [[ "$GL" == "gt" ]]; then sudo apt-get install -y python3-graph-tool; fi
-    - if [[ "$GL" == "ig" ]]; then pip3 install python-igraph; fi
-    - if [[ "$GL" == "nx" ]]; then pip3 install networkx; fi
+    - if [[ "$GL" == "gt" || "$GL" == "all" ]]; then
+        sudo apt-get install -y python3-graph-tool;
+      fi
+    - if [[ "$GL" == "ig" || "$GL" == "all" ]]; then
+        pip3 install python-igraph;
+      fi
+    - if [[ "$GL" == "nx" || "$GL" == "all" ]]; then pip3 install networkx; fi
 
-install: if [[ "$GL" == "gt" ]]; then sudo -H python3 setup.py install; else python setup.py install; fi
+install: if [[ "$GL" == "gt" || "$GL" == "all" ]]; then
+            sudo -H python3 setup.py install; else
+            python setup.py install;
+         fi
 
-script:
-    - coverage run -p -m pytest testing
-    - export OMP=4 && coverage run -p -m pytest testing
-    - export OMP=1 && export MPI=1 && mpirun --mca btl ^openib -n 2 coverage run -p -m pytest --with-mpi testing
-    - coverage combine
+script: if [[ "$GL" == "all" ]]; then
+            coverage run -p -m python3 testing/library_compatibility.py;
+        else
+            coverage run -p -m pytest testing;
+            export OMP=4 && coverage run -p -m pytest testing;
+            export OMP=1 && export MPI=1 && mpirun --mca btl ^openib -n 2 coverage run -p -m pytest --with-mpi testing;
+            coverage combine;
+        fi
 
 after_success: coveralls

--- a/.travis.yml
+++ b/.travis.yml
@@ -78,7 +78,7 @@ install: if [[ "$GL" == "gt" || "$GL" == "all" ]]; then
          fi
 
 script: if [[ "$GL" == "all" ]]; then
-            coverage run -p -m python3 testing/library_compatibility.py;
+            coverage run -p python3 testing/library_compatibility.py;
         else
             coverage run -p -m pytest testing;
             export OMP=4 && coverage run -p -m pytest testing;

--- a/.travis.yml
+++ b/.travis.yml
@@ -81,13 +81,13 @@ script:
     - if [[ "$GL" == "all" ]]; then
         coverage run -p testing/library_compatibility.py;
       fi
-    - if [[ "$GL" != "all"]; then
+    - if [[ "$GL" != "all"]]; then
         coverage run -p -m pytest testing;
       fi
-    - if [[ "$GL" != "all"]; then
+    - if [[ "$GL" != "all"]]; then
         export OMP=4 && coverage run -p -m pytest testing;
       fi
-    - if [[ "$GL" != "all"]; then
+    - if [[ "$GL" != "all"]]; then
         export OMP=1 && export MPI=1 && mpirun --mca btl ^openib -n 2 coverage run -p -m pytest --with-mpi testing;
       fi
     - coverage combine

--- a/.travis.yml
+++ b/.travis.yml
@@ -78,7 +78,7 @@ install: if [[ "$GL" == "gt" || "$GL" == "all" ]]; then
          fi
 
 script: if [[ "$GL" == "all" ]]; then
-            coverage run -p python3 testing/library_compatibility.py;
+            coverage run -p testing/library_compatibility.py;
         else
             coverage run -p -m pytest testing;
             export OMP=4 && coverage run -p -m pytest testing;

--- a/.travis.yml
+++ b/.travis.yml
@@ -81,13 +81,13 @@ script:
     - if [[ "$GL" == "all" ]]; then
         coverage run -p testing/library_compatibility.py;
       fi
-    - if [[ "$GL" != "all"]]; then
+    - if [[ "$GL" != "all" ]]; then
         coverage run -p -m pytest testing;
       fi
-    - if [[ "$GL" != "all"]]; then
+    - if [[ "$GL" != "all" ]]; then
         export OMP=4 && coverage run -p -m pytest testing;
       fi
-    - if [[ "$GL" != "all"]]; then
+    - if [[ "$GL" != "all" ]]; then
         export OMP=1 && export MPI=1 && mpirun --mca btl ^openib -n 2 coverage run -p -m pytest --with-mpi testing;
       fi
     - coverage combine

--- a/.travis.yml
+++ b/.travis.yml
@@ -77,13 +77,19 @@ install: if [[ "$GL" == "gt" || "$GL" == "all" ]]; then
             python setup.py install;
          fi
 
-script: if [[ "$GL" == "all" ]]; then
-            coverage run -p testing/library_compatibility.py;
-        else
-            coverage run -p -m pytest testing;
-            export OMP=4 && coverage run -p -m pytest testing;
-            export OMP=1 && export MPI=1 && mpirun --mca btl ^openib -n 2 coverage run -p -m pytest --with-mpi testing;
-            coverage combine;
-        fi
+script:
+    - if [[ "$GL" == "all" ]]; then
+        coverage run -p testing/library_compatibility.py;
+      fi
+    - if [[ "$GL" != "all"]; then
+        coverage run -p -m pytest testing;
+      fi
+    - if [[ "$GL" != "all"]; then
+        export OMP=4 && coverage run -p -m pytest testing;
+      fi
+    - if [[ "$GL" != "all"]; then
+        export OMP=1 && export MPI=1 && mpirun --mca btl ^openib -n 2 coverage run -p -m pytest --with-mpi testing;
+      fi
+    - coverage combine
 
 after_success: coveralls

--- a/.travis.yml
+++ b/.travis.yml
@@ -79,7 +79,7 @@ install: if [[ "$GL" == "gt" || "$GL" == "all" ]]; then
 
 script:
     - if [[ "$GL" == "all" ]]; then
-        coverage run -p testing/library_compatibility.py;
+        coverage run -p -m pytest testing/library_compatibility.py;
       fi
     - if [[ "$GL" != "all" ]]; then
         coverage run -p -m pytest testing;

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -518,6 +518,6 @@ extlinks_fancy = {
     'arxiv': (['https://arxiv.org/abs/{0}'], ['arXiv: {0}']),
     'gtdoc': (['https://graph-tool.skewed.de/static/doc/{0}.html#graph_tool.{1}'], ['graph-tool - {0}']),
     'igdoc': (['https://igraph.org/python/doc/igraph.GraphBase-class.html#{0}'], ['igraph - {0}']),
-    'nxdoc': (['https://networkx.github.io/documentation/stable/reference/{0}/generated/networkx.{1}.html'], ['networkx - {0}'])
+    'nxdoc': (['https://networkx.github.io/documentation/stable/reference/{0}generated/networkx.{1}.html'], ['networkx - {0}'])
 }
 

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -179,7 +179,8 @@ extensions = [
     'sphinx.ext.autosummary',
     'sphinx.ext.doctest',
     'sphinx.ext.napoleon',
-    'linksourcecode'
+    'linksourcecode',
+    'extlinks_fancy',
 ]
 
 # Add any paths that contain templates here, relative to this directory.
@@ -511,3 +512,12 @@ intersphinx_mapping = {
     'scipy': ('https://docs.scipy.org/doc/scipy/reference', None),
     'shapely': ('https://shapely.readthedocs.io/en/latest/', None),
 }
+
+extlinks_fancy = {
+    'doi': (['https://dx.doi.org/{0}'], ['DOI: {0}']),
+    'arxiv': (['https://arxiv.org/abs/{0}'], ['arXiv: {0}']),
+    'gtdoc': (['https://graph-tool.skewed.de/static/doc/{0}.html#graph_tool.{1}'], ['graph-tool - {0}']),
+    'igdoc': (['https://igraph.org/python/doc/igraph.GraphBase-class.html#{0}'], ['igraph - {0}']),
+    'nxdoc': (['https://networkx.github.io/documentation/stable/reference/{0}/generated/networkx.{1}.html'], ['networkx - {0}'])
+}
+

--- a/doc/examples/introductory_tutorial.py
+++ b/doc/examples/introductory_tutorial.py
@@ -118,7 +118,7 @@ if nngt.get_config("with_plot"):
     nplt.degree_distribution(g, ('in', 'total'), show=False)
 
 if nngt.get_config("backend") != "nngt":
-    print("Clustering ER: {}".format(na.clustering(g)))
+    print("Clustering ER: {}".format(na.undirected_local_clustering(g)))
 
 # then a scale-free network
 g = ng.random_scale_free(1.8, 3.2, nodes=1000, avg_deg=100)
@@ -128,4 +128,4 @@ if nngt.get_config("with_plot"):
                              logy=True, show=True)
 
 if nngt.get_config("backend") != "nngt":
-    print("Clustering SF: {}".format(na.clustering(g)))
+    print("Clustering SF: {}".format(na.undirected_local_clustering(g)))

--- a/doc/examples/multi_groups_network.py
+++ b/doc/examples/multi_groups_network.py
@@ -34,8 +34,8 @@ Make the population
 '''
 
 # two groups of neurons
-g1 = nngt.NeuralGroup(500)  # neurons 0 to 499
-g2 = nngt.NeuralGroup(500)  # neurons 500 to 999
+g1 = nngt.NeuralGroup(500, neuron_type=1)  # neurons 0 to 499
+g2 = nngt.NeuralGroup(500, neuron_type=1)  # neurons 500 to 999
 
 # make population (without NEST models)
 pop = nngt.NeuralPop.from_groups(

--- a/doc/examples/multi_groups_network.py
+++ b/doc/examples/multi_groups_network.py
@@ -75,10 +75,10 @@ if nngt.get_config("with_plot"):
 
     if nngt.get_config("backend") == "graph-tool":
         from graph_tool.draw import graph_draw, prop_to_size, sfdp_layout
-        pm = net.new_vertex_property("int", colors)
-        size = net.new_vertex_property("double", val=5.)
-        pos = sfdp_layout(net, groups=pm, C=1., K=20, gamma=5, mu=20)
-        graph_draw(net, pos=pos, vertex_fill_color=pm, vertex_color=pm,
+        pm = net.graph.new_vertex_property("int", colors)
+        size = net.graph.new_vertex_property("double", val=5.)
+        pos = sfdp_layout(net.graph, groups=pm, C=1., K=20, gamma=5, mu=20)
+        graph_draw(net.graph, pos=pos, vertex_fill_color=pm, vertex_color=pm,
                    vertex_size=size, nodesfirst=True,
                    edge_color=[0.179, 0.203,0.210, 0.3])
     elif nngt.get_config("backend") == "networkx":
@@ -87,13 +87,14 @@ if nngt.get_config("with_plot"):
         init_pos = {i: np.random.uniform(-1000., -900, 2) for i in range(500)}
         init_pos.update(
             {i: np.random.uniform(900., 1000, 2) for i in range(500, 1000)})
-        layout = nx.spring_layout(net, k=20, pos=init_pos)
+        layout = nx.spring_layout(net.graph, k=20, pos=init_pos)
         nx.draw(net, pos=layout, node_color=colors, node_size=20)
     elif nngt.get_config("backend") == "igraph":
         import igraph as ig
         colors = [(1, 0, 0) for _ in range(500)]
         colors.extend([(0, 0, 1) for _ in range(500)])
-        ig.plot(net, vertex_color=colors, vertex_size=5, edge_arrow_size=0.5)
+        ig.plot(net.graph, vertex_color=colors, vertex_size=5,
+                edge_arrow_size=0.5)
     else:
         nngt.plot.draw_network(net)
 

--- a/doc/examples/nest_network.py
+++ b/doc/examples/nest_network.py
@@ -39,11 +39,16 @@ params1.update({'E_L': -65., 'b': 40., 'I_e': 200., 'tau_w': 400.})
 params2.update({'b': 30., 'V_reset': -50., 'tau_w': 500.})
 
 oscill = nngt.NeuralGroup(
-    nodes=400, neuron_model='aeif_psc_alpha', neuron_param=params1)
+    nodes=400, neuron_model='aeif_psc_alpha', neuron_type=1,
+    neuron_param=params1)
+
 burst = nngt.NeuralGroup(
-    nodes=200, neuron_model='aeif_psc_alpha', neuron_param=params2)
+    nodes=200, neuron_model='aeif_psc_alpha', neuron_type=1,
+    neuron_param=params2)
+
 adapt = nngt.NeuralGroup(
-    nodes=200, neuron_model='aeif_psc_alpha', neuron_param=base_params)
+    nodes=200, neuron_model='aeif_psc_alpha', neuron_type=1,
+    neuron_param=base_params)
 
 synapses = {
     'default': {'model': 'tsodyks2_synapse'},

--- a/doc/examples/nest_receptor_ports.py
+++ b/doc/examples/nest_receptor_ports.py
@@ -85,5 +85,5 @@ if nngt.get_config('with_nest'):
 
     if nngt.get_config('with_plot'):
         ns.plot_activity(
-            recorder, record, network=net, show=True, hist=False,
+            recorder, record, network=net, show=True, histogram=False,
             limits=(0, simtime))

--- a/doc/examples/spatial_graphs.py
+++ b/doc/examples/spatial_graphs.py
@@ -81,4 +81,4 @@ os.remove('sp_graph.el')
 
 if nngt.get_config('with_plot'):
     print(g2.edge_nb(), g2.node_nb())
-    nngt.plot.draw_network(g2, decimate=100, show=True)
+    nngt.plot.draw_network(g2, decimate_connections=100, show=True)

--- a/doc/extensions/extlinks_fancy.py
+++ b/doc/extensions/extlinks_fancy.py
@@ -28,9 +28,19 @@ def make_link_role(base_urls, prefixes):
         for base_url, prefix in zip(base_urls, prefixes):
             full_url = None
 
-            if typ in ("gtdoc", "nxdoc"):
+            if typ == "gtdoc":
                 # graph-tool documentation formatting
-                module = part.split(".")[0]
+                module   = part.split(".")[0]
+                full_url = base_url.format(module, part)
+            elif typ == "nxdoc":
+                # networkx documentation formatting
+                module   = part.split(".")[0]
+
+                if not module:
+                    part = part[1:]
+                else:
+                    module += "/"
+
                 full_url = base_url.format(module, part)
             else:
                 full_url = base_url.format(part)

--- a/doc/extensions/extlinks_fancy.py
+++ b/doc/extensions/extlinks_fancy.py
@@ -1,0 +1,63 @@
+# -*- coding: utf-8 -*-
+"""
+    Extension to save typing and prevent hard-coding of base URLs in the reST
+    files.
+
+    This adds a new config value called ``extlinks_fancy`` that is created like this::
+
+       extlinks_fancy = {'exmpl': ('http://example.com/{0}.html', "Example {0}"), ...}
+
+    You can also give an explicit caption, e.g. :exmpl:`Foo <foo>`.
+
+    :copyright: Copyright 2007-2017 by the Sphinx team, see AUTHORS.
+    :license: BSD, see LICENSE for details.
+"""
+
+from six import iteritems
+from docutils import nodes, utils
+
+import sphinx
+from sphinx.util.nodes import split_explicit_title
+
+
+def make_link_role(base_urls, prefixes):
+    def role(typ, rawtext, text, lineno, inliner, options={}, content=[]):
+        text = utils.unescape(text)
+        has_explicit_title, title, part = split_explicit_title(text)
+        pnodes = []
+        for base_url, prefix in zip(base_urls, prefixes):
+            full_url = None
+
+            if typ in ("gtdoc", "nxdoc"):
+                # graph-tool documentation formatting
+                module = part.split(".")[0]
+                full_url = base_url.format(module, part)
+            else:
+                full_url = base_url.format(part)
+
+            if not has_explicit_title:
+                if prefix is None:
+                    title = full_url
+                else:
+                    title = prefix.format(part)
+            ref = nodes.reference(title, title, internal=False, refuri=full_url)
+            if len(pnodes) == 1:
+                pnodes.append(nodes.Text(" ["))
+            if len(pnodes) > 2:
+                pnodes.append(nodes.Text(", "))
+            pnodes.append(ref)
+        if len(base_urls) > 1:
+            pnodes.append(nodes.Text("]"))
+        return pnodes, []
+    return role
+
+
+def setup_link_roles(app):
+    for name, (base_urls, prefixes) in iteritems(app.config.extlinks_fancy):
+        app.add_role(name, make_link_role(base_urls, prefixes))
+
+
+def setup(app):
+    app.add_config_value('extlinks_fancy', {}, 'env')
+    app.connect('builder-inited', setup_link_roles)
+    return {'version': sphinx.__display_version__, 'parallel_read_safe': True}

--- a/doc/nngt_theme/static/nngt_theme.css
+++ b/doc/nngt_theme/static/nngt_theme.css
@@ -115,3 +115,9 @@ table.longtable {
 .admonition {
     font-size: 100%;
 }
+
+dl.citation dt.label {
+    background-color: none;
+    margin-right: 5px;
+    color: #000000;
+}

--- a/doc/pip-require.txt
+++ b/doc/pip-require.txt
@@ -10,6 +10,3 @@ peewee
 ##    Numpy/Scipy    ##
 numpy
 scipy
-
-##     Networkx      ##
-networkx

--- a/doc/user/graph-analysis.rst
+++ b/doc/user/graph-analysis.rst
@@ -40,33 +40,36 @@ the function will raise an error if one tries to use it on such graphs.
 +----------------------------------------------------+-----------------------+---------------------+---------------------+-------------------+
 |  Method                                            | Unweighted undirected | Unweighted directed | Weighted undirected | Weighted directed |
 +====================================================+=======================+=====================+=====================+===================+
-| :func:`~nngt.analysis.global_clustering`           |      gt, nx, ig       |         x           |    x                |    x              |
-+----------------------------------------------------+-----------------------+---------------------+---------------------+-------------------+
-| :func:`~nngt.analysis.undirected_local_clustering` |      gt, nx, ig       |         x           |    x                |    x              |
-+----------------------------------------------------+-----------------------+---------------------+---------------------+-------------------+
-| :func:`~nngt.analysis.assortativity`               |      gt, nx, ig       |     gt, nx, ig      |    gt, ig [1]_      |    gt, ig [1]_    |
-+----------------------------------------------------+-----------------------+---------------------+---------------------+-------------------+
-| :func:`~nngt.analysis.reciprocity`                 |      gt, nx, ig       |     gt, nx, ig      |    gt, nx, ig       |    gt, nx, ig     |
-+----------------------------------------------------+-----------------------+---------------------+---------------------+-------------------+
-| :func:`~nngt.analysis.closeness` [2]_              |      gt, nx, (ig)     |     gt, nx, (ig)    |    gt, nx, (ig)     |    gt, nx, (ig)   |
+| :func:`~nngt.analysis.assortativity` [1]_          |      gt, nx, ig       |     gt, nx, ig      |    gt, ig           |    gt, ig         |
 +----------------------------------------------------+-----------------------+---------------------+---------------------+-------------------+
 | :func:`~nngt.analysis.betweenness`                 |      gt, nx, ig       |     gt, nx, ig      |    gt, nx, ig       |    gt, nx, ig     |
++----------------------------------------------------+-----------------------+---------------------+---------------------+-------------------+
+| :func:`~nngt.analysis.closeness` [2]_              |      gt, nx, (ig)     |     gt, nx, (ig)    |    gt, nx, (ig)     |    gt, nx, (ig)   |
 +----------------------------------------------------+-----------------------+---------------------+---------------------+-------------------+
 | :func:`~nngt.analysis.connected_components`        |      gt, nx, ig       |     gt, nx, ig      |    gt, nx, ig       |    gt, nx, ig     |
 +----------------------------------------------------+-----------------------+---------------------+---------------------+-------------------+
 | :func:`~nngt.analysis.diameter` [3]_               |      gt, nx, ig       |     gt, nx, ig      |    gt, nx, ig       |    gt, nx, ig     |
 +----------------------------------------------------+-----------------------+---------------------+---------------------+-------------------+
+| :func:`~nngt.analysis.global_clustering`           |      gt, nx, ig       |         x           |    x                |    x              |
++----------------------------------------------------+-----------------------+---------------------+---------------------+-------------------+
+| :func:`~nngt.analysis.local_clustering`            |      gt, nx, ig       |         x           |    x                |    x              |
++----------------------------------------------------+-----------------------+---------------------+---------------------+-------------------+
+| :func:`~nngt.analysis.reciprocity`                 |      gt, nx, ig       |     gt, nx, ig      |    gt, nx, ig       |    gt, nx, ig     |
++----------------------------------------------------+-----------------------+---------------------+---------------------+-------------------+
+| :func:`~nngt.analysis.transitivity` [4]_           |      gt, nx, ig       |         x           |    x                |    x              |
++----------------------------------------------------+-----------------------+---------------------+---------------------+-------------------+
 
 
 .. [1] networkx could be used via a workaround but `an issue
        <https://github.com/networkx/networkx/issues/3917>`_ has been raised to
-       find out how to best deal with this
+       find out how to best deal with this.
 .. [2] since definitions of the maximum distances differ between libraries,
        igraph is currently not usable if the in- or out-degree of any of the
        nodes is zero; it also does not provide an implementation for the
-       harmonic closeness
+       harmonic closeness.
 .. [3] the implementation of the diameter for graph-tool is approximmate so
        results may occasionaly differ with this backend.
+.. [4] identical to ``global_clustering``.
 
 ----
 

--- a/doc/user/graph-analysis.rst
+++ b/doc/user/graph-analysis.rst
@@ -52,6 +52,10 @@ the function will raise an error if one tries to use it on such graphs.
 +----------------------------------------------------+-----------------------+---------------------+---------------------+-------------------+
 | :func:`~nngt.analysis.betweenness`                 |      gt, nx, ig       |     gt, nx, ig      |    gt, nx, ig       |    gt, nx, ig     |
 +----------------------------------------------------+-----------------------+---------------------+---------------------+-------------------+
+| :func:`~nngt.analysis.connected_components`        |      gt, nx, ig       |     gt, nx, ig      |    gt, nx, ig       |    gt, nx, ig     |
++----------------------------------------------------+-----------------------+---------------------+---------------------+-------------------+
+| :func:`~nngt.analysis.diameter` [3]_               |      gt, nx, ig       |     gt, nx, ig      |    gt, nx, ig       |    gt, nx, ig     |
++----------------------------------------------------+-----------------------+---------------------+---------------------+-------------------+
 
 
 .. [1] networkx could be used via a workaround but `an issue
@@ -61,7 +65,8 @@ the function will raise an error if one tries to use it on such graphs.
        igraph is currently not usable if the in- or out-degree of any of the
        nodes is zero; it also does not provide an implementation for the
        harmonic closeness
-
+.. [3] the implementation of the diameter for graph-tool is approximmate so
+       results may occasionaly differ with this backend.
 
 ----
 

--- a/doc/user/graph-analysis.rst
+++ b/doc/user/graph-analysis.rst
@@ -28,10 +28,20 @@ undirected networks, and whether they also work with weighted edges.
 +----------------------------------------------------+------------------------+---------------------+---------------------+-------------------+
 | :func:`~nngt.analysis.undirected_local_clustering` |       gt, nx, ig       |         x           |   x                 |  x                |
 +----------------------------------------------------+------------------------+---------------------+---------------------+-------------------+
-| :func:`~nngt.analysis.assortativity`               |       gt, nx, ig       |     gt, nx, ig      |    gt, ig [1]       |     gt, ig        |
+| :func:`~nngt.analysis.assortativity`               |       gt, nx, ig       |     gt, nx, ig      |    gt, ig [1]_      |    gt, ig         |
 +----------------------------------------------------+------------------------+---------------------+---------------------+-------------------+
-| :func:`~nngt.analysis.reciprocity`                 |       gt, nx, ig       |     gt, nx, ig      |     gt, ig nx       |    gt, ig, nx     |
+| :func:`~nngt.analysis.reciprocity`                 |       gt, nx, ig       |     gt, nx, ig      |     gt, nx, ig      |    gt, nx, ig     |
 +----------------------------------------------------+------------------------+---------------------+---------------------+-------------------+
+| :func:`~nngt.analysis.closeness` [2]_              |       gt, nx, (ig)     |     gt, nx, (ig)    |         x           |         x         |
++----------------------------------------------------+------------------------+---------------------+---------------------+-------------------+
+
+
+.. [1] networkx could be used via a workaround but `an issue
+       <https://github.com/networkx/networkx/issues/3917>`_ has been raised to
+       find out how to best deal with this
+.. [2] since definitions of the distances differ for the libraries, igraph is
+       currently not usable if the in- or out-degree of any of the nodes is
+       zero and does not provide an implementation for the harmonic closeness
 
 
 ----
@@ -45,11 +55,3 @@ undirected networks, and whether they also work with weighted edges.
 * :ref:`neural_groups`
 * :ref:`nest_int`
 * :ref:`activ_analysis`
-
-
-.. Links
-
-.. _global_clustering: 
-.. _global_clustering:
-
-.. [1]: networkx can be used via a workaround, `an issue <https://github.com/networkx/networkx/issues/3917>`_ has been raised to find out how to best deal with this

--- a/doc/user/graph-analysis.rst
+++ b/doc/user/graph-analysis.rst
@@ -28,6 +28,10 @@ undirected networks, and whether they also work with weighted edges.
 +----------------------------------------------------+------------------------+---------------------+---------------------+-------------------+
 | :func:`~nngt.analysis.undirected_local_clustering` |       gt, nx, ig       |         x           |   x                 |  x                |
 +----------------------------------------------------+------------------------+---------------------+---------------------+-------------------+
+| :func:`~nngt.analysis.assortativity`               |       gt, nx, ig       |     gt, nx, ig      |    gt, ig [1]       |     gt, ig        |
++----------------------------------------------------+------------------------+---------------------+---------------------+-------------------+
+| :func:`~nngt.analysis.reciprocity`                 |       gt, nx, ig       |     gt, nx, ig      |     gt, ig nx       |    gt, ig, nx     |
++----------------------------------------------------+------------------------+---------------------+---------------------+-------------------+
 
 
 ----
@@ -46,4 +50,6 @@ undirected networks, and whether they also work with weighted edges.
 .. Links
 
 .. _global_clustering: 
-.. _global_clustering: 
+.. _global_clustering:
+
+.. [1]: networkx can be used via a workaround, `an issue <https://github.com/networkx/networkx/issues/3917>`_ has been raised to find out how to best deal with this

--- a/doc/user/graph-analysis.rst
+++ b/doc/user/graph-analysis.rst
@@ -1,0 +1,49 @@
+.. _graph-analysis:
+
+==============
+Graph analysis
+==============
+
+NNGT provides several functions for topological analysis that return consistent
+results for all backends.
+This section describes these functions and gives an overview of the currently
+supported methods.
+
+**Content:**
+
+.. contents::
+   :local:
+
+
+Supported functions
+===================
+
+The following table details which functions are supported for directed and
+undirected networks, and whether they also work with weighted edges.
+
++----------------------------------------------------+------------------------+---------------------+---------------------+-------------------+
+| Method                                             | Unweighted, undirected | Unweighted directed | Weighted undirected | Weighted directed |
++====================================================+========================+=====================+=====================+===================+
+| :func:`~nngt.analysis.global_clustering`           |       gt, nx, ig       |         x           |   x                 |  x                |
++----------------------------------------------------+------------------------+---------------------+---------------------+-------------------+
+| :func:`~nngt.analysis.undirected_local_clustering` |       gt, nx, ig       |         x           |   x                 |  x                |
++----------------------------------------------------+------------------------+---------------------+---------------------+-------------------+
+
+
+----
+
+
+**Go to other tutorials:**
+
+* :ref:`intro`
+* :ref:`graph_gen`
+* :ref:`multithread`
+* :ref:`neural_groups`
+* :ref:`nest_int`
+* :ref:`activ_analysis`
+
+
+.. Links
+
+.. _global_clustering: 
+.. _global_clustering: 

--- a/doc/user/graph-analysis.rst
+++ b/doc/user/graph-analysis.rst
@@ -1,13 +1,22 @@
 .. _graph-analysis:
 
-==============
-Graph analysis
-==============
+===================================
+Consistent tools for graph analysis
+===================================
 
 NNGT provides several functions for topological analysis that return consistent
-results for all backends.
+results for all backends (the results will always be the same regardless of
+which library is used under the hood).
 This section describes these functions and gives an overview of the currently
 supported methods.
+
+.. note::
+    It is of course possible to use any function from the library on the
+    :attribute:`~nngt.Graph.graph` attribute; however, not using one of the
+    supported NNGT functions below will usually return results that are not
+    consistent between libraries (and the code will obviously no longer be
+    portable).
+
 
 **Content:**
 
@@ -21,27 +30,37 @@ Supported functions
 The following table details which functions are supported for directed and
 undirected networks, and whether they also work with weighted edges.
 
-+----------------------------------------------------+------------------------+---------------------+---------------------+-------------------+
-| Method                                             | Unweighted, undirected | Unweighted directed | Weighted undirected | Weighted directed |
-+====================================================+========================+=====================+=====================+===================+
-| :func:`~nngt.analysis.global_clustering`           |       gt, nx, ig       |         x           |   x                 |  x                |
-+----------------------------------------------------+------------------------+---------------------+---------------------+-------------------+
-| :func:`~nngt.analysis.undirected_local_clustering` |       gt, nx, ig       |         x           |   x                 |  x                |
-+----------------------------------------------------+------------------------+---------------------+---------------------+-------------------+
-| :func:`~nngt.analysis.assortativity`               |       gt, nx, ig       |     gt, nx, ig      |    gt, ig [1]_      |    gt, ig         |
-+----------------------------------------------------+------------------------+---------------------+---------------------+-------------------+
-| :func:`~nngt.analysis.reciprocity`                 |       gt, nx, ig       |     gt, nx, ig      |     gt, nx, ig      |    gt, nx, ig     |
-+----------------------------------------------------+------------------------+---------------------+---------------------+-------------------+
-| :func:`~nngt.analysis.closeness` [2]_              |       gt, nx, (ig)     |     gt, nx, (ig)    |         x           |         x         |
-+----------------------------------------------------+------------------------+---------------------+---------------------+-------------------+
+For each type of graph, the table tells which libraries are supported for the
+given function (graph-tool is `gt`, networkx is `nx` and igraph is `ig`).
+A library marked between parentheses denotes partial support and additional
+explanation is usually given in the footnotes.
+A cross means that no consistent implementation is currently provided and
+the function will raise an error if one tries to use it on such graphs.
+
++----------------------------------------------------+-----------------------+---------------------+---------------------+-------------------+
+|  Method                                            | Unweighted undirected | Unweighted directed | Weighted undirected | Weighted directed |
++====================================================+=======================+=====================+=====================+===================+
+| :func:`~nngt.analysis.global_clustering`           |      gt, nx, ig       |         x           |    x                |    x              |
++----------------------------------------------------+-----------------------+---------------------+---------------------+-------------------+
+| :func:`~nngt.analysis.undirected_local_clustering` |      gt, nx, ig       |         x           |    x                |    x              |
++----------------------------------------------------+-----------------------+---------------------+---------------------+-------------------+
+| :func:`~nngt.analysis.assortativity`               |      gt, nx, ig       |     gt, nx, ig      |    gt, ig [1]_      |    gt, ig [1]_    |
++----------------------------------------------------+-----------------------+---------------------+---------------------+-------------------+
+| :func:`~nngt.analysis.reciprocity`                 |      gt, nx, ig       |     gt, nx, ig      |    gt, nx, ig       |    gt, nx, ig     |
++----------------------------------------------------+-----------------------+---------------------+---------------------+-------------------+
+| :func:`~nngt.analysis.closeness` [2]_              |      gt, nx, (ig)     |     gt, nx, (ig)    |    gt, nx, (ig)     |    gt, nx, (ig)   |
++----------------------------------------------------+-----------------------+---------------------+---------------------+-------------------+
+| :func:`~nngt.analysis.betweenness`                 |      gt, nx, ig       |     gt, nx, ig      |    gt, nx, ig       |    gt, nx, ig     |
++----------------------------------------------------+-----------------------+---------------------+---------------------+-------------------+
 
 
 .. [1] networkx could be used via a workaround but `an issue
        <https://github.com/networkx/networkx/issues/3917>`_ has been raised to
        find out how to best deal with this
-.. [2] since definitions of the distances differ for the libraries, igraph is
-       currently not usable if the in- or out-degree of any of the nodes is
-       zero and does not provide an implementation for the harmonic closeness
+.. [2] since definitions of the maximum distances differ between libraries,
+       igraph is currently not usable if the in- or out-degree of any of the
+       nodes is zero; it also does not provide an implementation for the
+       harmonic closeness
 
 
 ----

--- a/doc/user/graph-analysis.rst
+++ b/doc/user/graph-analysis.rst
@@ -32,32 +32,42 @@ undirected networks, and whether they also work with weighted edges.
 
 For each type of graph, the table tells which libraries are supported for the
 given function (graph-tool is `gt`, networkx is `nx` and igraph is `ig`).
+Custom implementation of a function is denoted by `nngt`, meaning that the
+function can be used even if no graph library is installed.
 A library marked between parentheses denotes partial support and additional
 explanation is usually given in the footnotes.
 A cross means that no consistent implementation is currently provided and
 the function will raise an error if one tries to use it on such graphs.
 
-+----------------------------------------------------+-----------------------+---------------------+---------------------+-------------------+
-|  Method                                            | Unweighted undirected | Unweighted directed | Weighted undirected | Weighted directed |
-+====================================================+=======================+=====================+=====================+===================+
-| :func:`~nngt.analysis.assortativity` [1]_          |      gt, nx, ig       |     gt, nx, ig      |    gt, ig           |    gt, ig         |
-+----------------------------------------------------+-----------------------+---------------------+---------------------+-------------------+
-| :func:`~nngt.analysis.betweenness`                 |      gt, nx, ig       |     gt, nx, ig      |    gt, nx, ig       |    gt, nx, ig     |
-+----------------------------------------------------+-----------------------+---------------------+---------------------+-------------------+
-| :func:`~nngt.analysis.closeness` [2]_              |      gt, nx, (ig)     |     gt, nx, (ig)    |    gt, nx, (ig)     |    gt, nx, (ig)   |
-+----------------------------------------------------+-----------------------+---------------------+---------------------+-------------------+
-| :func:`~nngt.analysis.connected_components`        |      gt, nx, ig       |     gt, nx, ig      |    gt, nx, ig       |    gt, nx, ig     |
-+----------------------------------------------------+-----------------------+---------------------+---------------------+-------------------+
-| :func:`~nngt.analysis.diameter` [3]_               |      gt, nx, ig       |     gt, nx, ig      |    gt, nx, ig       |    gt, nx, ig     |
-+----------------------------------------------------+-----------------------+---------------------+---------------------+-------------------+
-| :func:`~nngt.analysis.global_clustering`           |      gt, nx, ig       |         x           |    x                |    x              |
-+----------------------------------------------------+-----------------------+---------------------+---------------------+-------------------+
-| :func:`~nngt.analysis.local_clustering`            |      gt, nx, ig       |         x           |    x                |    x              |
-+----------------------------------------------------+-----------------------+---------------------+---------------------+-------------------+
-| :func:`~nngt.analysis.reciprocity`                 |      gt, nx, ig       |     gt, nx, ig      |    gt, nx, ig       |    gt, nx, ig     |
-+----------------------------------------------------+-----------------------+---------------------+---------------------+-------------------+
-| :func:`~nngt.analysis.transitivity` [4]_           |      gt, nx, ig       |         x           |    x                |    x              |
-+----------------------------------------------------+-----------------------+---------------------+---------------------+-------------------+
++----------------------------------------------------+-----------------------+---------------------+---------------------+--------------------+
+|  Method                                            | Unweighted undirected | Unweighted directed | Weighted undirected | Weighted directed  |
++====================================================+=======================+=====================+=====================+====================+
+| :func:`~nngt.analysis.assortativity` [1]_          |    gt, nx, ig         |   gt, nx, ig        |   gt, ig            |   gt, ig           |
++----------------------------------------------------+-----------------------+---------------------+---------------------+--------------------+
+| :func:`~nngt.analysis.betweenness`                 |    gt, nx, ig         |   gt, nx, ig        |   gt, nx, ig        |   gt, nx, ig       |
++----------------------------------------------------+-----------------------+---------------------+---------------------+--------------------+
+| :func:`~nngt.analysis.betweenness_distrib`         |    gt, nx, ig         |   gt, nx, ig        |   gt, nx, ig        |   gt, nx, ig       |
++----------------------------------------------------+-----------------------+---------------------+---------------------+--------------------+
+| :func:`~nngt.analysis.closeness` [2]_              |    gt, nx, (ig)       |   gt, nx, (ig)      |   gt, nx, (ig)      |   gt, nx, (ig)     |
++----------------------------------------------------+-----------------------+---------------------+---------------------+--------------------+
+| :func:`~nngt.analysis.connected_components`        |    gt, nx, ig         |   gt, nx, ig        |   gt, nx, ig        |   gt, nx, ig       |
++----------------------------------------------------+-----------------------+---------------------+---------------------+--------------------+
+| :func:`~nngt.analysis.degree_distrib`              |    gt, nx, ig, nngt   |   gt, nx, ig, nngt  |   gt, nx, ig, nngt  |   gt, nx, ig, nngt |
++----------------------------------------------------+-----------------------+---------------------+---------------------+--------------------+
+| :func:`~nngt.analysis.diameter` [3]_               |    gt, nx, ig         |   gt, nx, ig        |   gt, nx, ig        |   gt, nx, ig       |
++----------------------------------------------------+-----------------------+---------------------+---------------------+--------------------+
+| :func:`~nngt.analysis.global_clustering`           |    gt, nx, ig         |   x                 |   x                 |   x                |
++----------------------------------------------------+-----------------------+---------------------+---------------------+--------------------+
+| :func:`~nngt.analysis.local_clustering`            |    gt, nx, ig         |   x                 |   x                 |   x                |
++----------------------------------------------------+-----------------------+---------------------+---------------------+--------------------+
+| :func:`~nngt.analysis.reciprocity`                 |    gt, nx, ig         |   gt, nx, ig        |   gt, nx, ig        |   gt, nx, ig       |
++----------------------------------------------------+-----------------------+---------------------+---------------------+--------------------+
+| :func:`~nngt.analysis.spectral_radius`             |    nngt               |   nngt              |   nngt              |   nngt             |
++----------------------------------------------------+-----------------------+---------------------+---------------------+--------------------+
+| :func:`~nngt.analysis.subgraph_centrality`         |    nngt               |   nngt              |   nngt              |   nngt             |
++----------------------------------------------------+-----------------------+---------------------+---------------------+--------------------+
+| :func:`~nngt.analysis.transitivity` [4]_           |    gt, nx, ig         |   x                 |   x                 |   x                |
++----------------------------------------------------+-----------------------+---------------------+---------------------+--------------------+
 
 
 .. [1] networkx could be used via a workaround but `an issue
@@ -68,7 +78,7 @@ the function will raise an error if one tries to use it on such graphs.
        nodes is zero; it also does not provide an implementation for the
        harmonic closeness.
 .. [3] the implementation of the diameter for graph-tool is approximmate so
-       results may occasionaly differ with this backend.
+       results may occasionaly be inexact with this backend.
 .. [4] identical to ``global_clustering``.
 
 ----

--- a/doc/user/intro.rst
+++ b/doc/user/intro.rst
@@ -30,6 +30,7 @@ separately in the following pages:
 
    graph-generation
    component-properties
+   graph-analysis
    multithreading
    neural-groups
    nest-interaction

--- a/doc/user/nest-interaction.rst
+++ b/doc/user/nest-interaction.rst
@@ -119,7 +119,7 @@ Since we are using NEST, these properties are:
 * the type of the neurons (``1`` for excitatory or ``-1`` for inhibitory)
 
 .. literalinclude:: ../examples/nest_network.py
-   :lines: 29-68
+   :lines: 29-73
 
 Once this network is created, it can simply be sent to nest through the
 command: ``gids = net.to_nest()``, and the NEST gids are returned.

--- a/doc/user/tutorial.rst
+++ b/doc/user/tutorial.rst
@@ -227,7 +227,7 @@ Since we are using NEST, these properties are:
 * the type of the neurons (``1`` for excitatory or ``-1`` for inhibitory)
 
 .. literalinclude:: ../examples/nest_network.py
-   :lines: 29-68
+   :lines: 29-73
 
 Once this network is created, it can simply be sent to nest through the
 command: ``gids = net.to_nest()``, and the NEST gids are returned.

--- a/nngt/analysis/graph_analysis.py
+++ b/nngt/analysis/graph_analysis.py
@@ -47,7 +47,8 @@ __all__ = [
 	"reciprocity",
 	"spectral_radius",
     "subgraph_centrality",
-    "transitivity"
+    "transitivity",
+    "undirected_local_clustering"
 ]
 
 

--- a/nngt/analysis/graph_analysis.py
+++ b/nngt/analysis/graph_analysis.py
@@ -175,6 +175,33 @@ def closeness(graph, nodes=None, use_weights=False):
     return nngt.analyze_graph["closeness"](graph, nodes, use_weights)
 
 
+def betweenness(g, btype="both", weights=None, norm=True):
+    '''
+    Returns the betweenness centrality.
+
+    Parameters
+    ----------
+    g : :class:`~nngt.Graph`
+        Graph to analyze.
+    btype : str, optional (default: "both")
+        The type of betweenness that will be returned ("node" or "edge").
+    
+
+    References
+    ----------
+    .. [gt-betw] https://graph-tool.skewed.de/static/doc/centrality.html#graph_tool.centrality.betweenness
+    .. [ig-betw] https://graph-tool.skewed.de/static/doc/centrality.html#graph_tool.centrality.betweenness
+    .. [betweenness-wikipedia] http://en.wikipedia.org/wiki/Centrality#Betweenness_centrality
+    '''
+    use_weights = True if weights in (True, 'weight') else False
+
+    if not use_weights and weights not in (None, False):
+        raise RuntimeError("backend implementation does not support specific "
+                           "attributes as weights yet, will come soon.")
+
+    return g.betweenness_list(btype=btype, use_weights=use_weights, norm=norm):
+
+
 def local_clustering(graph, nodes=None):
     '''
     Local clustering coefficient of the nodes.

--- a/nngt/analysis/graph_analysis.py
+++ b/nngt/analysis/graph_analysis.py
@@ -418,12 +418,12 @@ def local_clustering(g, weights=None, nodes=None):
                               "directed graphs.")
 
 
-def subgraph_centrality(graph, weights=True, normalize="max_centrality"):
+def subgraph_centrality(graph, weights=True, nodes=None,
+                        normalize="max_centrality"):
     '''
-    Subgraph centrality, accordign to [Estrada2005]_, for each node in the
-    graph.
+    Returns the subgraph centrality for each node in the graph.
 
-    Defined as:
+    Defined according to [Estrada2005]_ as:
 
     .. math::
 
@@ -442,11 +442,14 @@ def subgraph_centrality(graph, weights=True, normalize="max_centrality"):
         is returned, if `weights` is a string, then the ponderation is the
         correponding value of the edge attribute (e.g. "distance" will return
         an adjacency matrix where each connection is multiplied by its length).
-    normalize : str, optional (default: "max_centrality")
+    nodes : array-like container with node ids, optional (default = all nodes)
+        Nodes for which the subgraph centrality should be returned (all
+        centralities are computed anyway in the algorithm).
+    normalize : str or False, optional (default: "max_centrality")
         Whether the centrality should be normalized. Accepted normalizations
-        are "max_eigenvalue" and "max_centrality"; the first rescales the
-        adjacency matrix by the its largest eigenvalue before taking the
-        exponential, the second sets the maximum centrality to one.
+        are "max_eigenvalue" (the matrix is divided by its largest eigenvalue),
+        "max_centrality" (the largest centrality is one), and ``False`` to get
+        the non-normalized centralities.
 
     Returns
     -------
@@ -457,7 +460,7 @@ def subgraph_centrality(graph, weights=True, normalize="max_centrality"):
     ----------
     .. [Estrada2005] Ernesto Estrada and Juan A. Rodríguez-Velázquez,
     Subgraph centrality in complex networks, PHYSICAL REVIEW E 71, 056103
-    (2005), :doi:`10.1103/PhysRevE.71.056103`, :arxiv:`0504730`.
+    (2005), :doi:`10.1103/PhysRevE.71.056103`, :arxiv:`cond-mat/0504730`.
     '''
     adj_mat = graph.adjacency_matrix(types=False, weights=weights).tocsc()
 
@@ -469,10 +472,16 @@ def subgraph_centrality(graph, weights=True, normalize="max_centrality"):
     elif normalize == "max_eigenvalue":
         norm, _ = spl.eigs(adj_mat, k=1)
         centralities = spl.expm(adj_mat / norm).diagonal()
+    elif normalize is False:
+        centralities = spl.expm(adj_mat).diagonal()
     else:
         raise InvalidArgument('`normalize` should be either False, "eigenmax",'
                               ' or "centralmax".')
-    return centralities
+
+    if nodes is None:
+        return centralities
+
+    return centralities[nodes]
 
 
 # ------------------- #

--- a/nngt/analysis/graph_analysis.py
+++ b/nngt/analysis/graph_analysis.py
@@ -190,7 +190,8 @@ def betweenness(g, btype="both", weights=None, norm=True):
     References
     ----------
     .. [gt-betw] https://graph-tool.skewed.de/static/doc/centrality.html#graph_tool.centrality.betweenness
-    .. [ig-betw] https://graph-tool.skewed.de/static/doc/centrality.html#graph_tool.centrality.betweenness
+    .. [ig-betw] https://igraph.org/python/doc/igraph.GraphBase-class.html#betweenness
+    .. [ig-edge-betw] https://igraph.org/python/doc/igraph.GraphBase-class.html#edge_betweenness
     .. [betweenness-wikipedia] http://en.wikipedia.org/wiki/Centrality#Betweenness_centrality
     '''
     use_weights = True if weights in (True, 'weight') else False
@@ -199,7 +200,7 @@ def betweenness(g, btype="both", weights=None, norm=True):
         raise RuntimeError("backend implementation does not support specific "
                            "attributes as weights yet, will come soon.")
 
-    return g.betweenness_list(btype=btype, use_weights=use_weights, norm=norm):
+    return g.betweenness_list(btype=btype, use_weights=use_weights, norm=norm)
 
 
 def local_clustering(graph, nodes=None):

--- a/nngt/analysis/graph_analysis.py
+++ b/nngt/analysis/graph_analysis.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 #-*- coding:utf-8 -*-
 #
 # This file is part of the NNGT project to generate and analyze
@@ -93,8 +92,10 @@ def degree_distrib(graph, deg_type="total", node_list=None, use_weights=False,
         bins
     '''
     degrees = graph.get_degrees(deg_type, node_list, use_weights)
+
     if num_bins == 'bayes' or is_integer(num_bins):
         num_bins = binning(degrees, bins=num_bins, log=log)
+
     return np.histogram(degrees, num_bins)
 
 

--- a/nngt/analysis/graph_analysis.py
+++ b/nngt/analysis/graph_analysis.py
@@ -162,7 +162,7 @@ def num_iedges(graph):
 
     For :class:`~nngt.Network` objects, this corresponds to the number of edges
     stemming from inhibitory nodes (given by
-    :meth:`~nngt.NeuralPop.inhibitory`).
+    :meth:`nngt.NeuralPop.inhibitory`).
     Otherwise, counts the edges where the type attribute is -1.
     '''
     if graph.is_network():
@@ -170,7 +170,10 @@ def num_iedges(graph):
 
         return np.sum(graph.get_degrees("out", node_list=inhib_nodes))
 
-    return np.sum(graph.get_edge_attributes(name="type") < 0)
+    if "type" in graph.edges_attributes:
+        return np.sum(graph.get_edge_attributes(name="type") < 0)
+
+    return 0.
 
 
 def connected_components(g, ctype=None):
@@ -459,8 +462,8 @@ def subgraph_centrality(graph, weights=True, nodes=None,
     References
     ----------
     .. [Estrada2005] Ernesto Estrada and Juan A. Rodríguez-Velázquez,
-    Subgraph centrality in complex networks, PHYSICAL REVIEW E 71, 056103
-    (2005), :doi:`10.1103/PhysRevE.71.056103`, :arxiv:`cond-mat/0504730`.
+       Subgraph centrality in complex networks, PHYSICAL REVIEW E 71, 056103
+       (2005), :doi:`10.1103/PhysRevE.71.056103`, :arxiv:`cond-mat/0504730`.
     '''
     adj_mat = graph.adjacency_matrix(types=False, weights=weights).tocsc()
 
@@ -521,7 +524,7 @@ def spectral_radius(graph, typed=True, weights=True):
     raise spl.eigen.arpack.ArpackNoConvergence()
 
 
-def adjacency_matrix(graph, types=True, weights=True):
+def adjacency_matrix(graph, types=False, weights=False):
     '''
     Adjacency matrix of the graph.
 
@@ -529,10 +532,10 @@ def adjacency_matrix(graph, types=True, weights=True):
     ----------
     graph : :class:`~nngt.Graph` or subclass
         Network to analyze.
-    types : bool, optional (default: True)
+    types : bool, optional (default: False)
         Whether the excitatory/inhibitory type of the connnections should be
         considered (only if the weighing factor is the synaptic strength).
-    weights : bool or string, optional (default: True)
+    weights : bool or string, optional (default: False)
         Whether weights should be taken into account; if True, then connections
         are weighed by their synaptic strength, if False, then a binary matrix
         is returned, if `weights` is a string, then the ponderation is the
@@ -736,7 +739,7 @@ def degree_distrib(graph, deg_type="total", nodes=None, weights=None,
     deg : :class:`numpy.array`
         bins
     '''
-    degrees = graph.get_degrees(deg_type, node_list, use_weights)
+    degrees = graph.get_degrees(deg_type, nodes, weights)
 
     if num_bins == 'bayes' or is_integer(num_bins):
         num_bins = binning(degrees, bins=num_bins, log=log)

--- a/nngt/analysis/graph_analysis.py
+++ b/nngt/analysis/graph_analysis.py
@@ -34,7 +34,7 @@ __all__ = [
     "betweenness_distrib",
     "binning",
 	"closeness",
-	"clustering",
+	"global_clustering",
     "degree_distrib",
 	"diameter",
     "local_clustering",
@@ -49,253 +49,122 @@ __all__ = [
 ]
 
 
-# ------------- #
-# Distributions #
-# ------------- #
-
-def degree_distrib(graph, deg_type="total", node_list=None, use_weights=False,
-                   log=False, num_bins='bayes'):
-    '''
-    Degree distribution of a graph.
-
-    .. versionchanged:: 0.7
-
-    Inclusion of automatic binning.
-
-    Parameters
-    ----------
-    graph : :class:`~nngt.Graph` or subclass
-        the graph to analyze.
-    deg_type : string, optional (default: "total")
-        type of degree to consider ("in", "out", or "total").
-    node_list : list or numpy.array of ints, optional (default: None)
-        Restrict the distribution to a set of nodes (default: all nodes).
-    use_weights : bool, optional (default: False)
-        use weighted degrees (do not take the sign into account: all weights
-        are positive).
-    log : bool, optional (default: False)
-        use log-spaced bins.
-    num_bins : int, list or str, optional (default: 'bayes')
-        Any of the automatic methodes from :func:`numpy.histogram`, or 'bayes'
-        will provide automatic bin optimization. Otherwise, an int for the
-        number of bins can be provided, or the direct bins list.
-
-    See also
-    --------
-    :func:`numpy.histogram`, :func:`~nngt.analysis.binning`
-
-    Returns
-    -------
-    counts : :class:`numpy.array`
-        number of nodes in each bin
-    deg : :class:`numpy.array`
-        bins
-    '''
-    degrees = graph.get_degrees(deg_type, node_list, use_weights)
-
-    if num_bins == 'bayes' or is_integer(num_bins):
-        num_bins = binning(degrees, bins=num_bins, log=log)
-
-    return np.histogram(degrees, num_bins)
-
-
-def betweenness_distrib(graph, use_weights=True, nodes=None, num_nbins='bayes',
-                        num_ebins='bayes', log=False):
-    '''
-    Betweenness distribution of a graph.
-
-    Parameters
-    ----------
-    graph : :class:`~nngt.Graph` or subclass
-        the graph to analyze.
-    use_weights : bool, optional (default: True)
-        use weighted degrees (do not take the sign into account : all weights
-        are positive).
-    nodes : list or numpy.array of ints, optional (default: all nodes)
-        Restrict the distribution to a set of nodes (only impacts the node
-        attribute).
-    log : bool, optional (default: False)
-        use log-spaced bins.
-    num_bins : int, list or str, optional (default: 'bayes')
-        Any of the automatic methodes from :func:`numpy.histogram`, or 'bayes'
-        will provide automatic bin optimization. Otherwise, an int for the
-        number of bins can be provided, or the direct bins list.
-
-    Returns
-    -------
-    ncounts : :class:`numpy.array`
-        number of nodes in each bin
-    nbetw : :class:`numpy.array`
-        bins for node betweenness
-    ecounts : :class:`numpy.array`
-        number of edges in each bin
-    ebetw : :class:`numpy.array`
-        bins for edge betweenness
-    '''
-    ia_nbetw, ia_ebetw = graph.get_betweenness(
-        btype="both", use_weights=use_weights)
-
-    if nodes is not None:
-        ia_nbetw = ia_nbetw[nodes]
-    ra_nbins, ra_ebins = None, None
-    if num_ebins == 'bayes' or log:
-        ra_ebins = binning(ia_ebetw, bins=num_ebins, log=log)
-    else:
-        ra_ebins = num_ebins
-    if num_nbins == 'bayes' or log:
-        ra_nbins = binning(ia_nbetw, bins=num_nbins, log=log)
-    else:
-        ra_nbins = num_nbins
-
-    ra_ebins = binning(ia_ebetw, bins=num_ebins, log=log)
-
-    ncounts, nbetw = np.histogram(ia_nbetw, ra_nbins)
-    ecounts, ebetw = np.histogram(ia_ebetw, ra_ebins)
-
-    return ncounts, nbetw, ecounts, ebetw
-
-
-# --------------- #
-# Node properties #
-# --------------- #
-
-def closeness(graph, nodes=None, use_weights=False):
-    '''
-    Return the closeness centrality for each node in `nodes`.
-
-    Parameters
-    ----------
-    graph : :class:`~nngt.Graph` object
-        Graph to analyze.
-    nodes : array-like container with node ids, optional (default = all nodes)
-        Nodes for which the local clustering coefficient should be computed.
-    use_weights : bool, optional (default: False)
-        Whether weighted closeness should be used.
-    '''
-    return nngt.analyze_graph["closeness"](graph, nodes, use_weights)
-
-
-def betweenness(g, btype="both", weights=None, norm=True):
-    '''
-    Returns the betweenness centrality.
-
-    Parameters
-    ----------
-    g : :class:`~nngt.Graph`
-        Graph to analyze.
-    btype : str, optional (default: "both")
-        The type of betweenness that will be returned ("node" or "edge").
-    
-
-    References
-    ----------
-    .. [gt-betw] https://graph-tool.skewed.de/static/doc/centrality.html#graph_tool.centrality.betweenness
-    .. [ig-betw] https://igraph.org/python/doc/igraph.GraphBase-class.html#betweenness
-    .. [ig-edge-betw] https://igraph.org/python/doc/igraph.GraphBase-class.html#edge_betweenness
-    .. [betweenness-wikipedia] http://en.wikipedia.org/wiki/Centrality#Betweenness_centrality
-    '''
-    use_weights = True if weights in (True, 'weight') else False
-
-    if not use_weights and weights not in (None, False):
-        raise RuntimeError("backend implementation does not support specific "
-                           "attributes as weights yet, will come soon.")
-
-    return g.betweenness_list(btype=btype, use_weights=use_weights, norm=norm)
-
-
-def local_clustering(graph, nodes=None):
-    '''
-    Local clustering coefficient of the nodes.
-    Defined as
-
-    .. math::
-        c_i = 3 \\times \\frac{\\text{triangles}}{\\text{connected triples}}
-
-    Parameters
-    ----------
-    graph : :class:`~nngt.Graph` object
-        Graph to analyze.
-    nodes : array-like container with node ids, optional (default = all nodes)
-        Nodes for which the local clustering coefficient should be computed.
-    '''
-    if nngt._config["backend"] == "igraph":
-        return np.array(graph.graph.transitivity_local_undirected(nodes))
-
-    return nngt.analyze_graph["local_clustering"](graph, nodes)
+_backend_required = "Please install either networkx, igraph, or graph-tool " \
+                    "to use this function."
 
 
 # ---------------- #
 # Graph properties #
 # ---------------- #
 
-def assortativity(graph, deg_type="in"):
+def assortativity(g, degree, weights=None):
     '''
-    Assortativity of the graph.
+    Returns the assortativity of the graph.
+    This tells whether nodes are preferentially connected together depending
+    on their degree.
 
     Parameters
     ----------
-    graph : :class:`~nngt.Graph` or subclass
-        Network to analyze.
-    deg_type : string, optional (default: 'in')
-        Type of degree to take into account (among 'in', 'out' or 'total').
+    g : :class:`~nngt.Graph`
+        Graph to analyze.
+    degree : str
+        The type of degree that should be considered.
+    weights : bool or str, optional (default: binary edges)
+        Whether edge weights should be considered; if ``None`` or ``False``
+        then use binary edges; if ``True``, uses the 'weight' edge attribute,
+        otherwise uses any valid edge attribute required.
 
-    Returns
-    -------
-    a float quantifying the graph assortativity.
+    References
+    ----------
+    .. [newman-mixing-2003] M. E. J. Newman, "Mixing patterns in networks",
+        Phys. Rev. E 67, 026126 (2003), see graph-tool below for links.
+    .. [gt-assortativity] :gtdoc:`correlations.scalar_assortativity`
+    .. [ig-assortativity] :igdoc:`assortativity`
+    .. [nx-assortativity]
+       :nxdoc:`algorithms.assortativity.degree_assortativity_coefficient`
     '''
-    if nngt._config["backend"] == "igraph":
-        deg_list = graph.get_degrees(deg_type=deg_type)
-        return graph.graph.assortativity(deg_list,
-                                         directed=graph.is_directed())
-    elif nngt._config["backend"] == "graph-tool":
-        return nngt.analyze_graph["assortativity"](graph, deg_type)[0]
-    else:
-        if deg_type == 'total':
-            raise InvalidArgument("Cannot use total degree assortativity with "
-                                  "`networkx`.")
-        return nngt.analyze_graph["assortativity"](graph, x=deg_type,
-                                                   y=deg_type)
+    raise NotImplementedError(_backend_required)
 
 
-def reciprocity(graph):
+def reciprocity(g):
     '''
-    Graph reciprocity, defined as :math:`E^\leftrightarrow/E`,
-    where :math:`E^\leftrightarrow` and :math:`E` are, respectively, the number
-    of bidirectional edges and the total number of edges in the graph.
+    Calculate the edge reciprocity of the graph.
 
-    Returns
-    -------
-    a float quantifying the reciprocity.
+    The reciprocity is defined as the number of edges that have a reciprocal
+    edge (an edge between the same nodes but in the opposite direction)
+    divided by the total number of edges.
+    This is also the probability for any given edge, that its reciprocal edge
+    exists.
+    By definition, the reciprocity of undirected graphs is 1.
+
+    @todo: check whether we can get this for single nodes for all libraries.
+
+    Parameters
+    ----------
+    g : :class:`~nngt.Graph`
+        Graph to analyze.
+
+    References
+    ----------
+    .. [wasserman-1994] S. Wasserman and K. Faust, "Social Network Analysis".
+       (Cambridge University Press, Cambridge, 1994)
+    .. [lopez-2007] Gorka Zamora-López, Vinko Zlatić, Changsong
+       Zhou, Hrvoje Štefančić, and Jürgen Kurths "Reciprocity of networks with
+       degree correlations and arbitrary degree sequences", Phys. Rev. E 77,
+       016106 (2008) :doi:`10.1103/PhysRevE.77.016106`, :arxiv:`0706.3372`
+    .. [gt-reciprocity] :gtdoc:`topology.edge_reciprocity`
+    .. [ig-reciprocity] :igdoc:`reciprocity`
+    .. [nx-reciprocity] :nxdoc:`algorithms.reciprocity.overall_reciprocity`
     '''
-    if nngt._config["backend"] == "igraph":
-        return graph.graph.reciprocity()
-    else:
-        return nngt.analyze_graph["reciprocity"](graph)
+    raise NotImplementedError(_backend_required)
 
 
-def clustering(graph):
+def global_clustering(g, weights=None):
     '''
-    Global clustering coefficient of the graph.
-    Defined as:
+    Returns the undirected global clustering coefficient.
+    This corresponds to the ratio of undirected triangles to the number of
+    undirected triads.
 
-    .. math::
-        c = 3 \\times \\frac{\\text{triangles}}{\\text{connected triples}}
+    Parameters
+    ----------
+    g : :class:`~nngt.Graph`
+        Graph to analyze.
+    weights : bool or str, optional (default: binary edges)
+        Whether edge weights should be considered; if ``None`` or ``False``
+        then use binary edges; if ``True``, uses the 'weight' edge attribute,
+        otherwise uses any valid edge attribute required.
+
+    Note
+    ----
+    If `weights` is None, returns the transitivity (number of existing
+    triangles over total number of possible triangles); otherwise returns
+    the average clustering.
+
+    References
+    ----------
+    .. [gt-global-clustering] :gtdoc:`clustering.global_clustering`
+    .. [ig-global-clustering] :igdoc:`transitivity_undirected`
+    .. [nx-global-clustering] :nxdoc:`algorithms.cluster.transitivity`
     '''
-    if nngt._config["backend"] == "igraph":
-        return graph.graph.transitivity_undirected()
-    else:
-        return nngt.analyze_graph["clustering"](graph)
+    raise NotImplementedError(_backend_required)
 
 
-def transitivity(graph):
+def transitivity(g, weights=None):
     '''
-    Same as :func:`nngt.analysis.clustering` (for networkx users)
+    Same as :func:`~nngt.analysis.global_clustering`.
     '''
-    return clustering(graph)
+    return global_clustering(g, weights=weights)
 
 
 def num_iedges(graph):
-    ''' Returns the number of inhibitory connections. '''
+    '''
+    Returns the number of inhibitory connections.
+
+    For :class:`~nngt.Network` objects, this corresponds to the number of edges
+    stemming from inhibitory nodes (given by
+    :meth:`~nngt.NeuralPop.inhibitory`).
+    Otherwise, counts the edges where the type attribute is -1.
+    '''
     if graph.is_network():
         inhib_nodes = graph.population.inhibitory
 
@@ -372,6 +241,180 @@ def diameter(graph):
     return nngt.analyze_graph["diameter"](graph)[0]
 
 
+# ------------ #
+# Centralities #
+# ------------ #
+
+def closeness(graph, nodes=None, use_weights=False):
+    '''
+    Return the closeness centrality for each node in `nodes`.
+
+    Parameters
+    ----------
+    graph : :class:`~nngt.Graph` object
+        Graph to analyze.
+    nodes : array-like container with node ids, optional (default = all nodes)
+        Nodes for which the local clustering coefficient should be computed.
+    use_weights : bool, optional (default: False)
+        Whether weighted closeness should be used.
+    '''
+    raise NotImplementedError(_backend_required)
+
+
+def betweenness(g, btype="both", weights=None, norm=True):
+    '''
+    Returns the normalized betweenness centrality of the nodes and edges.
+
+    Parameters
+    ----------
+    g : :class:`~nngt.Graph`
+        Graph to analyze.
+    btype : str, optional (default 'both')
+        The centrality that should be returned (either 'node', 'edge', or
+        'both'). By default, both betweenness centralities are computed.
+    weights : bool or str, optional (default: binary edges)
+        Whether edge weights should be considered; if ``None`` or ``False``
+        then use binary edges; if ``True``, uses the 'weight' edge attribute,
+        otherwise uses any valid edge attribute required.
+
+    Returns
+    -------
+    nb : :class:`numpy.ndarray`
+        The nodes' betweenness if `btype` is 'node' or 'both'
+    eb : :class:`numpy.ndarray`
+        The edges' betweenness if `btype` is 'edge' or 'both'
+
+    References
+    ----------
+    .. [betweenness-wikipedia] http://en.wikipedia.org/wiki/Centrality#Betweenness_centrality
+    .. [gt-betw] https://graph-tool.skewed.de/static/doc/centrality.html#graph_tool.centrality.betweenness
+    .. [ig-betw] https://igraph.org/python/doc/igraph.GraphBase-class.html#betweenness
+    .. [ig-edge-betw] https://igraph.org/python/doc/igraph.GraphBase-class.html#edge_betweenness
+    .. [nx-ebetw] https://networkx.github.io/documentation/stable/reference/algorithms/generated/networkx.algorithms.centrality.edge_betweenness_centrality.html#networkx.algorithms.centrality.edge_betweenness_centrality
+    .. [nx-nbetw] https://networkx.github.io/documentation/stable/reference/algorithms/generated/networkx.algorithms.centrality.betweenness_centrality.html#networkx.algorithms.centrality.betweenness_centrality
+    '''
+    raise NotImplementedError(_backend_required)
+
+
+def undirected_local_clustering(g, weights=None, nodes=None,
+                                combine_weights="sum"):
+    '''
+    Returns the undirected local clustering coefficient of some `nodes`.
+
+    If `g` is directed, then it is converted to a simple undirected graph
+    (no parallel edges).
+
+    Parameters
+    ----------
+    g : :class:`~nngt.Graph`
+        Graph to analyze.
+    weights : bool or str, optional (default: binary edges)
+        Whether edge weights should be considered; if ``None`` or ``False``
+        then use binary edges; if ``True``, uses the 'weight' edge attribute,
+        otherwise uses any valid edge attribute required.
+    nodes : list, optional (default: all nodes)
+        The list of nodes for which the clutering will be returned
+    combine_weights : str, optional (default: "sum")
+        How the weights of directed edges between two nodes should be combined,
+        among:
+
+        * "sum": the sum of the edge attribute values will be used for the new
+          edge.
+        * "product": the product of the edge attribute values will be used for
+          the new edge.
+        * "mean": the mean of the edge attribute values will be used for the
+          new edge.
+        * "median": the median of the edge attribute values will be used for
+          the new edge.
+        * "min": the minimum of the edge attribute values will be used for the
+          new edge.
+        * "max": the maximum of the edge attribute values will be used for the
+          new edge. 
+
+    Returns
+    -------
+    lc : :class:`numpy.ndarray`
+        The list of clustering coefficients, on per node.
+
+    References
+    ----------
+    .. [gt-local-clustering] :gtdoc:`clustering.locall_clustering`
+    .. [ig-local-clustering] :igdoc:`transitivity_local_undirected`
+    .. [nx-local-clustering] :nxdoc:`algorithms.cluster.clustering`
+    '''
+    raise NotImplementedError(_backend_required)
+
+
+def local_clustering(g, weights=None, nodes=None):
+    '''
+    Local clustering coefficient of the nodes.
+
+    Parameters
+    ----------
+    g : :class:`~nngt.Graph` object
+        Graph to analyze.
+    weights : bool or str, optional (default: binary edges)
+        Whether edge weights should be considered; if ``None`` or ``False``
+        then use binary edges; if ``True``, uses the 'weight' edge attribute,
+        otherwise uses any valid edge attribute required.
+    nodes : array-like container with node ids, optional (default = all nodes)
+        Nodes for which the local clustering coefficient should be computed.
+    '''
+    if not graph.is_directed():
+        return undirected_local_clustering(g, weights=weights, nodes=nodes)
+
+    raise NotImplementedError("`local_clustering` is not yet implemented for "
+                              "directed graphs.")
+
+
+def subgraph_centrality(graph, weights=True, normalize="max_centrality"):
+    '''
+    Subgraph centrality, accordign to [Estrada2005], for each node in the
+    graph.
+
+    Parameters
+    ----------
+    graph : :class:`~nngt.Graph` or subclass
+        Network to analyze.
+    weights : bool or string, optional (default: True)
+        Whether weights should be taken into account; if True, then connections
+        are weighed by their synaptic strength, if False, then a binary matrix
+        is returned, if `weights` is a string, then the ponderation is the
+        correponding value of the edge attribute (e.g. "distance" will return
+        an adjacency matrix where each connection is multiplied by its length).
+    normalize : str, optional (default: "max_centrality")
+        Whether the centrality should be normalized. Accepted normalizations
+        are "max_eigenvalue" and "max_centrality"; the first rescales the
+        adjacency matrix by the its largest eigenvalue before taking the
+        exponential, the second sets the maximum centrality to one.
+
+    Returns
+    -------
+    centralities : :class:`numpy.ndarray`
+        The subgraph centrality of each node.
+
+    References
+    ----------
+    .. [Estrada2005] Ernesto Estrada and Juan A. Rodríguez-Velázquez,
+    Subgraph centrality in complex networks, PHYSICAL REVIEW E 71, 056103
+    (2005), `available on ArXiv <http://www.arxiv.org/pdf/cond-mat/0504730>`_.
+    '''
+    adj_mat = graph.adjacency_matrix(types=False, weights=weights).tocsc()
+
+    centralities = None
+
+    if normalize == "max_centrality":
+        centralities = spl.expm(adj_mat / adj_mat.max()).diagonal()
+        centralities /= centralities.max()
+    elif normalize == "max_eigenvalue":
+        norm, _ = spl.eigs(adj_mat, k=1)
+        centralities = spl.expm(adj_mat / norm).diagonal()
+    else:
+        raise InvalidArgument('`normalize` should be either False, "eigenmax",'
+                              ' or "centralmax".')
+    return centralities
+
+
 # ------------------- #
 # Spectral properties #
 # ------------------- #
@@ -433,56 +476,9 @@ def adjacency_matrix(graph, types=True, weights=True):
     return graph.adjacency_matrix(types=types, weights=weights)
 
 
-def subgraph_centrality(graph, weights=True, normalize="max_centrality"):
-    '''
-    Subgraph centrality, accordign to [Estrada2005], for each node in the
-    graph.
-
-    **[Estrada2005]:** Ernesto Estrada and Juan A. Rodríguez-Velázquez,
-    Subgraph centrality in complex networks, PHYSICAL REVIEW E 71, 056103
-    (2005),
-    `available on ArXiv <http://www.arxiv.org/pdf/cond-mat/0504730>`_.
-
-    Parameters
-    ----------
-    graph : :class:`~nngt.Graph` or subclass
-        Network to analyze.
-    weights : bool or string, optional (default: True)
-        Whether weights should be taken into account; if True, then connections
-        are weighed by their synaptic strength, if False, then a binary matrix
-        is returned, if `weights` is a string, then the ponderation is the
-        correponding value of the edge attribute (e.g. "distance" will return
-        an adjacency matrix where each connection is multiplied by its length).
-    normalize : str, optional (default: "max_centrality")
-        Whether the centrality should be normalized. Accepted normalizations
-        are "max_eigenvalue" and "max_centrality"; the first rescales the
-        adjacency matrix by the its largest eigenvalue before taking the
-        exponential, the second sets the maximum centrality to one.
-
-    Returns
-    -------
-    centralities : :class:`numpy.ndarray`
-        The subgraph centrality of each node.
-    '''
-    adj_mat = graph.adjacency_matrix(types=False, weights=weights).tocsc()
-
-    centralities = None
-
-    if normalize == "max_centrality":
-        centralities = spl.expm(adj_mat / adj_mat.max()).diagonal()
-        centralities /= centralities.max()
-    elif normalize == "max_eigenvalue":
-        norm, _ = spl.eigs(adj_mat, k=1)
-        centralities = spl.expm(adj_mat / norm).diagonal()
-    else:
-        raise InvalidArgument('`normalize` should be either False, "eigenmax",'
-                              ' or "centralmax".')
-    return centralities
-
-
-# ----------------------- #
-# Get all node properties #
-# ----------------------- #
+# --------------- #
+# Node properties #
+# --------------- #
 
 def node_attributes(network, attributes, nodes=None, data=None):
     '''
@@ -622,6 +618,113 @@ def find_nodes(network, attributes, equal=None, upper_bound=None,
     nodes = nodes.intersection_update(np.array(nodes)[keep])
 
     return nodes
+
+
+# ------------- #
+# Distributions #
+# ------------- #
+
+def degree_distrib(graph, deg_type="total", nodes=None, weights=None,
+                   log=False, num_bins='bayes'):
+    '''
+    Degree distribution of a graph.
+
+    .. versionchanged:: 0.7
+
+    Inclusion of automatic binning.
+
+    Parameters
+    ----------
+    graph : :class:`~nngt.Graph` or subclass
+        the graph to analyze.
+    deg_type : string, optional (default: "total")
+        type of degree to consider ("in", "out", or "total").
+    nodes : list of ints, optional (default: None)
+        Restrict the distribution to a set of nodes (default: all nodes).
+    weights : bool or str, optional (default: binary edges)
+        Whether edge weights should be considered; if ``None`` or ``False``
+        then use binary edges; if ``True``, uses the 'weight' edge attribute,
+        otherwise uses any valid edge attribute required.
+    log : bool, optional (default: False)
+        use log-spaced bins.
+    num_bins : int, list or str, optional (default: 'bayes')
+        Any of the automatic methodes from :func:`numpy.histogram`, or 'bayes'
+        will provide automatic bin optimization. Otherwise, an int for the
+        number of bins can be provided, or the direct bins list.
+
+    See also
+    --------
+    :func:`numpy.histogram`, :func:`~nngt.analysis.binning`
+
+    Returns
+    -------
+    counts : :class:`numpy.array`
+        number of nodes in each bin
+    deg : :class:`numpy.array`
+        bins
+    '''
+    degrees = graph.get_degrees(deg_type, node_list, use_weights)
+
+    if num_bins == 'bayes' or is_integer(num_bins):
+        num_bins = binning(degrees, bins=num_bins, log=log)
+
+    return np.histogram(degrees, num_bins)
+
+
+def betweenness_distrib(graph, weights=None, nodes=None, num_nbins='bayes',
+                        num_ebins='bayes', log=False):
+    '''
+    Betweenness distribution of a graph.
+
+    Parameters
+    ----------
+    graph : :class:`~nngt.Graph` or subclass
+        the graph to analyze.
+    weights : bool or str, optional (default: binary edges)
+        Whether edge weights should be considered; if ``None`` or ``False``
+        then use binary edges; if ``True``, uses the 'weight' edge attribute,
+        otherwise uses any valid edge attribute required.
+    nodes : list or numpy.array of ints, optional (default: all nodes)
+        Restrict the distribution to a set of nodes (only impacts the node
+        attribute).
+    log : bool, optional (default: False)
+        use log-spaced bins.
+    num_bins : int, list or str, optional (default: 'bayes')
+        Any of the automatic methodes from :func:`numpy.histogram`, or 'bayes'
+        will provide automatic bin optimization. Otherwise, an int for the
+        number of bins can be provided, or the direct bins list.
+
+    Returns
+    -------
+    ncounts : :class:`numpy.array`
+        number of nodes in each bin
+    nbetw : :class:`numpy.array`
+        bins for node betweenness
+    ecounts : :class:`numpy.array`
+        number of edges in each bin
+    ebetw : :class:`numpy.array`
+        bins for edge betweenness
+    '''
+    ia_nbetw, ia_ebetw = betweenness(graph, btype="both", weights=use_weights)
+
+    if nodes is not None:
+        ia_nbetw = ia_nbetw[nodes]
+    ra_nbins, ra_ebins = None, None
+    if num_ebins == 'bayes' or log:
+        ra_ebins = binning(ia_ebetw, bins=num_ebins, log=log)
+    else:
+        ra_ebins = num_ebins
+    if num_nbins == 'bayes' or log:
+        ra_nbins = binning(ia_nbetw, bins=num_nbins, log=log)
+    else:
+        ra_nbins = num_nbins
+
+    ra_ebins = binning(ia_ebetw, bins=num_ebins, log=log)
+
+    ncounts, nbetw = np.histogram(ia_nbetw, ra_nbins)
+    ecounts, ebetw = np.histogram(ia_ebetw, ra_ebins)
+
+    return ncounts, nbetw, ecounts, ebetw
 
 
 # ----- #

--- a/nngt/analysis/graph_analysis.py
+++ b/nngt/analysis/graph_analysis.py
@@ -28,6 +28,8 @@ from .activity_analysis import get_b2, get_firing_rate
 from .bayesian_blocks import bayesian_blocks
 
 
+# implemented function; import from proper backend is done at the bottom
+
 __all__ = [
     "adjacency_matrix",
     "assortativity",
@@ -781,7 +783,7 @@ def betweenness_distrib(graph, weights=None, nodes=None, num_nbins='bayes',
     ebetw : :class:`numpy.array`
         bins for edge betweenness
     '''
-    ia_nbetw, ia_ebetw = betweenness(graph, btype="both", weights=use_weights)
+    ia_nbetw, ia_ebetw = betweenness(graph, btype="both", weights=weights)
 
     if nodes is not None:
         ia_nbetw = ia_nbetw[nodes]
@@ -874,3 +876,17 @@ def _get_attribute(network, attribute, nodes=None, data=None):
         return network.get_node_attributes(nodes=nodes, name=attribute)
 
     raise RuntimeError("Attribute '{}' is not available.".format(attribute))
+
+
+# ------------------------------------ #
+# Importing backend-specific functions #
+# ------------------------------------ #
+
+if nngt._config["backend"] == "networkx":
+    from .nx_functions import *
+
+if nngt._config["backend"] == "igraph":
+    from .ig_functions import *
+
+if nngt._config["backend"] == "graph-tool":
+    from .gt_functions import *

--- a/nngt/analysis/graph_analysis.py
+++ b/nngt/analysis/graph_analysis.py
@@ -248,7 +248,7 @@ def diameter(g, weights=False):
 
 def closeness(g, weights=None, nodes=None, mode="out", harmonic=False,
               default=np.NaN):
-    '''
+    r'''
     Returns the closeness centrality of some `nodes`.
 
     Closeness centrality of a node `u` is defined, for the harmonic version,
@@ -707,10 +707,6 @@ def degree_distrib(graph, deg_type="total", nodes=None, weights=None,
                    log=False, num_bins='bayes'):
     '''
     Degree distribution of a graph.
-
-    .. versionchanged:: 0.7
-
-    Inclusion of automatic binning.
 
     Parameters
     ----------

--- a/nngt/analysis/gt_functions.py
+++ b/nngt/analysis/gt_functions.py
@@ -390,8 +390,9 @@ def diameter(g, weights=False):
     '''
     Returns the pseudo-diameter of the graph.
 
-    @todo: check what happens if some nodes are disconnected (with and
-    without weights)
+    This function returns an approximmation of the graph diameter.
+    It returns infinity if the graph is not connected (strongly connected for
+    directed graphs).
 
     Parameters
     ----------
@@ -407,6 +408,12 @@ def diameter(g, weights=False):
     .. [gt-diameter] https://graph-tool.skewed.de/static/doc/topology.html#graph_tool.topology.pseudo_diameter
     '''
     ww = _get_weights(g, weights)
+
+    # first check whether the graph is fully connected
+    cc, hist = connected_components(g)
+
+    if len(hist) > 1:
+        return np.inf
 
     return gtt.pseudo_diameter(g.graph, weights=ww)[0]
 

--- a/nngt/analysis/gt_functions.py
+++ b/nngt/analysis/gt_functions.py
@@ -245,7 +245,7 @@ def closeness(g, weights=None, nodes=None, mode="out", harmonic=False,
 
     References
     ----------
-    .. [gt-closeness] https://graph-tool.skewed.de/static/doc/centrality.html#graph_tool.centrality.closeness
+    .. [gt-closeness] :gtdoc:`centrality.closeness`
     '''
     ww = _get_weights(g, weights)
 
@@ -290,7 +290,7 @@ def betweenness(g, btype="both", weights=None):
 
     References
     ----------
-    .. [gt-betw] https://graph-tool.skewed.de/static/doc/centrality.html#graph_tool.centrality.betweenness
+    .. [gt-betw] :gtdoc:`centrality.betweenness`
     '''
     w = _get_weights(g, weights)
 
@@ -328,7 +328,7 @@ def connected_components(g, ctype=None):
 
     References
     ----------
-    .. [gt-connected-components] https://graph-tool.skewed.de/static/doc/topology.html#graph_tool.topology.label_components
+    .. [gt-connected-components] :gtdoc:`topology.label_components`
     '''
     ctype = "scc" if ctype is None else ctype
 
@@ -336,7 +336,7 @@ def connected_components(g, ctype=None):
         raise ValueError("`ctype` must be either 'scc' or 'wcc'.")
 
     directed  = True if ctype == "scc" else False
-    directed *= g.is_directed() 
+    directed *= g.is_directed()
 
     cc, hist = gtt.label_components(g.graph, directed=directed)
 
@@ -362,7 +362,7 @@ def diameter(g, weights=False):
 
     References
     ----------
-    .. [gt-diameter] https://graph-tool.skewed.de/static/doc/topology.html#graph_tool.topology.pseudo_diameter
+    .. [gt-diameter] :gtdoc:`topology.pseudo_diameter`
     '''
     ww = _get_weights(g, weights)
 

--- a/nngt/analysis/gt_functions.py
+++ b/nngt/analysis/gt_functions.py
@@ -373,12 +373,13 @@ def connected_components(g, ctype=None):
     ----------
     .. [gt-connected-components] https://graph-tool.skewed.de/static/doc/topology.html#graph_tool.topology.label_components
     '''
-    ctype    = "scc" if ctype is None else ctype
+    ctype = "scc" if ctype is None else ctype
 
     if ctype not in ("scc", "wcc"):
         raise ValueError("`ctype` must be either 'scc' or 'wcc'.")
 
-    directed = True if ctype == "scc" else False
+    directed  = True if ctype == "scc" else False
+    directed *= g.is_directed() 
 
     cc, hist = gtt.label_components(g.graph, directed=directed)
 

--- a/nngt/analysis/gt_functions.py
+++ b/nngt/analysis/gt_functions.py
@@ -373,7 +373,15 @@ def connected_components(g, ctype=None):
     ----------
     .. [gt-connected-components] https://graph-tool.skewed.de/static/doc/topology.html#graph_tool.topology.label_components
     '''
-    cc, hist = gtt.label_components(g.graph, *args, **kwargs)
+    ctype    = "scc" if ctype is None else ctype
+
+    if ctype not in ("scc", "wcc"):
+        raise ValueError("`ctype` must be either 'scc' or 'wcc'.")
+
+    directed = True if ctype == "scc" else False
+
+    cc, hist = gtt.label_components(g.graph, directed=directed)
+
     return cc.a, hist
 
 

--- a/nngt/analysis/gt_functions.py
+++ b/nngt/analysis/gt_functions.py
@@ -1,0 +1,263 @@
+#-*- coding:utf-8 -*-
+#
+# gt_functions.py
+#
+# This file is part of the NNGT project to generate and analyze
+# neuronal networks and their activity.
+# Copyright (C) 2015-2019  Tanguy Fardet
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+""" Tools to analyze graphs with the graph-tool backend """
+
+from graph_tool.spectral import adjacency
+from graph_tool.centrality import closeness as gt_closeness
+from graph_tool.correlations import scalar_assortativity
+from graph_tool.topology import (edge_reciprocity,
+                                 label_components, pseudo_diameter)
+from graph_tool.clustering import global_clustering as gt_gc
+from graph_tool.clustering import local_clustering as gt_lc
+
+
+def global_clustering(g, weights=None):
+    '''
+    Returns the global clustering coefficient.
+
+    Parameters
+    ----------
+    g : :class:`~nngt.Graph`
+        Graph to analyze.
+    weights : bool or str, optional (default: binary edges)
+        Whether edge weights should be considered; if ``None`` or ``False``
+        then use binary edges; if ``True``, uses the 'weight' edge attribute,
+        otherwise uses any valid edge attribute required.
+
+    References
+    ----------
+    .. [gt-global-clustering] https://graph-tool.skewed.de/static/doc/clustering.html#graph_tool.clustering.global_clustering
+    '''
+    ww = _get_weights(g, weights)
+
+    return gt_gc(g.graph, weight=ww)[0]
+
+
+def local_clustering(g, weights=False, nodes=None):
+    '''
+    Returns the local clustering coefficient of some `nodes`.
+
+    Parameters
+    ----------
+    g : :class:`~nngt.Graph`
+        Graph to analyze.
+    weights : bool or str, optional (default: binary edges)
+        Whether edge weights should be considered; if ``None`` or ``False``
+        then use binary edges; if ``True``, uses the 'weight' edge attribute,
+        otherwise uses any valid edge attribute required.
+    nodes : list, optional (default: all nodes)
+        The list of nodes for which the clutering will be returned
+
+    Returns
+    -------
+    lc : :class:`numpy.ndarray`
+        The list of clustering coefficients, on per node.
+
+    References
+    ----------
+    .. [gt-local-clustering] https://graph-tool.skewed.de/static/doc/clustering.html#graph_tool.clustering.local_clustering
+    '''
+    ww = _get_weights(g, weights)
+
+    lc = gt_lc(g.graph, weight=ww).a
+
+    if nodes is None:
+        return lc
+
+    return lc[nodes]
+
+
+def assortativity(g, degree, weights=None):
+    '''
+    Returns the assortativity of the graph.
+    This tells whether nodes are preferentially connected together depending
+    on their degree.
+
+    Parameters
+    ----------
+    g : :class:`~nngt.Graph`
+        Graph to analyze.
+    degree : str
+        The type of degree that should be considered.
+    weights : bool or str, optional (default: binary edges)
+        Whether edge weights should be considered; if ``None`` or ``False``
+        then use binary edges; if ``True``, uses the 'weight' edge attribute,
+        otherwise uses any valid edge attribute required.
+
+    References
+    ----------
+    .. [gt-assortativity] https://graph-tool.skewed.de/static/doc/correlations.html#graph_tool.correlations.scalar_assortativity
+    '''
+    ww = _get_weights(g, weights)
+
+    return scalar_assortativity(g.graph, degree, eweight=ww)
+
+
+def reciprocity(g):
+    '''
+    Calculate the edge reciprocity of the graph.
+
+    Parameters
+    ----------
+    g : :class:`~nngt.Graph`
+        Graph to analyze.
+
+    References
+    ----------
+    .. [gt-reciprocity] https://graph-tool.skewed.de/static/doc/topology.html#graph_tool.topology.edge_reciprocity
+    '''
+    return edge_reciprocity(g.graph)
+
+
+def closeness(g, weighted=False, nodes=None):
+    '''
+    Returns the closeness centrality of some `nodes`.
+
+    Parameters
+    ----------
+    g : :class:`~nngt.Graph`
+        Graph to analyze.
+    weights : bool or str, optional (default: binary edges)
+        Whether edge weights should be considered; if ``None`` or ``False``
+        then use binary edges; if ``True``, uses the 'weight' edge attribute,
+        otherwise uses any valid edge attribute required.
+    nodes : list, optional (default: all nodes)
+        The list of nodes for which the clutering will be returned
+
+    Returns
+    -------
+    c : :class:`numpy.ndarray`
+        The list of closeness centralities, on per node.
+
+    References
+    ----------
+    .. [gt-closeness] https://graph-tool.skewed.de/static/doc/centrality.html#graph_tool.centrality.closeness
+    '''
+    ww = _get_weights(g, weights)
+
+    c = closeness(g.graph, weight=ww)
+
+    if nodes is None:
+        return c.a
+
+    return c.a[nodes]
+
+
+def connected_components(g, ctype=None):
+    '''
+    Returns the connected component to which each node belongs.
+
+    Parameters
+    ----------
+    g : :class:`~nngt.Graph`
+        Graph to analyze.
+    ctype : str, optional (default 'scc')
+        Type of component that will be searched: either strongly connected
+        ('scc', by default) or weakly connected ('wcc').
+
+    Returns
+    -------
+    cc, hist : :class:`numpy.ndarray`
+        The component associated to each node (`cc`) and the number of nodes in
+        each of the component (`hist`).
+
+    References
+    ----------
+    .. [gt-connected-components] https://graph-tool.skewed.de/static/doc/topology.html#graph_tool.topology.label_components
+    '''
+    cc, hist = label_components(g.graph, *args, **kwargs)
+    return cc.a, hist
+
+
+def diameter(g, weighted=False):
+    '''
+    Returns the pseudo-diameter of the graph.
+
+    Parameters
+    ----------
+    g : :class:`~nngt.Graph`
+        Graph to analyze.
+    weights : bool or str, optional (default: binary edges)
+        Whether edge weights should be considered; if ``None`` or ``False``
+        then use binary edges; if ``True``, uses the 'weight' edge attribute,
+        otherwise uses any valid edge attribute required.
+
+    References
+    ----------
+    .. [gt-diameter] https://graph-tool.skewed.de/static/doc/topology.html#graph_tool.topology.pseudo_diameter
+    '''
+    ww = _get_weights(g, weights)
+
+    return pseudo_diameter(g.graph, weights=ww)
+
+
+def adj_mat(g, weights=None):
+    r'''
+    Returns the adjacency matrix :math:`A` of the graph.
+    With edge :math:`i \leftarrow j` corresponding to entry :math:`A_{ij}`.
+
+    Parameters
+    ----------
+    g : :class:`~nngt.Graph`
+        Graph to analyze.
+    weights : bool or str, optional (default: binary edges)
+        Whether edge weights should be considered; if ``None`` or ``False``
+        then returns the binary adjacency matrix; if ``True``, returns the
+        weighted matrix, otherwise fills the matrix with any valid edge
+        attribute values.
+
+    Returns
+    -------
+    The adjacency matrix as a :class:`scipy.sparse.csr_matrix`.
+
+    References
+    ----------
+    .. [gt-adjacency] https://graph-tool.skewed.de/static/doc/spectral.html#graph_tool.spectral.adjacency
+    '''
+    ww = _get_weights(g, weights)
+
+    return _adj(g.graph, ww).T
+
+
+def get_edges(g):
+    '''
+    Returns the edges in the graph by order of creation.
+    '''
+    return g.graph.edges()
+
+
+def _get_weights(g, weights):
+    if weights in g.edges_attributes:
+        # existing edge attribute
+        return g.graph.edge_properties[weights]
+    elif nonstring_container(weights):
+        # user-provided array
+        return g.graph.new_edge_property("double", vals=weights)
+    elif weights is True:
+        # "normal" weights
+        return g.graph.edge_properties['weight']
+    elif not weights:
+        # unweighted
+        return None
+
+    raise ValueError("Unknown edge attribute '" + str(weights) + "'.")
+    

--- a/nngt/analysis/gt_functions.py
+++ b/nngt/analysis/gt_functions.py
@@ -188,7 +188,7 @@ def reciprocity(g):
 
 def closeness(g, weights=None, nodes=None, mode="out", harmonic=False,
               default=np.NaN):
-    '''
+    r'''
     Returns the closeness centrality of some `nodes`.
 
     Closeness centrality of a node `u` is defined, for the harmonic version,

--- a/nngt/analysis/gt_functions.py
+++ b/nngt/analysis/gt_functions.py
@@ -54,56 +54,13 @@ def global_clustering(g, weights=None):
 
     References
     ----------
-    .. [gt-global-clustering] https://graph-tool.skewed.de/static/doc/clustering.html#graph_tool.clustering.global_clustering
+    .. [gt-global-clustering] :gtdoc:`clustering.global_clustering`
     '''
     # use undirected graph view, filter parallel edges
     u = GraphView(g.graph, directed=False)
     u = GraphView(u, efilt=label_parallel_edges(u).fa == 0)
 
     return gtc.global_clustering(u, weight=None)[0]
-
-
-def local_clustering(g, weights=None, nodes=None):
-    '''
-    Returns the undirected local clustering coefficient of some `nodes`.
-
-    Parameters
-    ----------
-    g : :class:`~nngt.Graph`
-        Graph to analyze.
-    weights : bool or str, optional (default: binary edges)
-        Whether edge weights should be considered; if ``None`` or ``False``
-        then use binary edges; if ``True``, uses the 'weight' edge attribute,
-        otherwise uses any valid edge attribute required.
-    nodes : list, optional (default: all nodes)
-        The list of nodes for which the clutering will be returned
-
-    Returns
-    -------
-    lc : :class:`numpy.ndarray`
-        The list of clustering coefficients, on per node.
-
-    References
-    ----------
-    .. [gt-local-clustering] https://graph-tool.skewed.de/static/doc/clustering.html#graph_tool.clustering.local_clustering
-    '''
-    ww = _get_weights(g, weights)
-
-    # store previous value
-    directed = g.is_directed()
-
-    # set graph to undirected and compute clustering
-    g.graph.set_directed(False)
-
-    lc = gtc.local_clustering(g.graph, weight=ww, undirected=True).a
-
-    # switch back to previous value
-    g.graph.set_directed(directed)
-
-    if nodes is None:
-        return lc
-
-    return lc[nodes]
 
 
 def undirected_local_clustering(g, weights=None, nodes=None,
@@ -145,7 +102,7 @@ def undirected_local_clustering(g, weights=None, nodes=None,
 
     References
     ----------
-    .. [gt-local-clustering] https://graph-tool.skewed.de/static/doc/clustering.html#graph_tool.clustering.local_clustering
+    .. [gt-local-clustering] :gtdoc:`clustering.locall_clustering`
     '''
     if weights is not None:
         raise NotImplementedError("graph-tool backend currently does not "
@@ -188,7 +145,7 @@ def assortativity(g, degree, weights=None):
 
     References
     ----------
-    .. [gt-assortativity] https://graph-tool.skewed.de/static/doc/correlations.html#graph_tool.correlations.scalar_assortativity
+    .. [gt-assortativity] :gtdoc:`correlations.scalar_assortativity`
     '''
     ww = _get_weights(g, weights)
 
@@ -224,7 +181,7 @@ def reciprocity(g):
 
     References
     ----------
-    .. [gt-reciprocity] https://graph-tool.skewed.de/static/doc/topology.html#graph_tool.topology.edge_reciprocity
+    .. [gt-reciprocity] :gtdoc:`topology.edge_reciprocity`
     '''
     return gtt.edge_reciprocity(g.graph)
 

--- a/nngt/analysis/ig_functions.py
+++ b/nngt/analysis/ig_functions.py
@@ -1,0 +1,267 @@
+#-*- coding:utf-8 -*-
+#
+# gt_functions.py
+#
+# This file is part of the NNGT project to generate and analyze
+# neuronal networks and their activity.
+# Copyright (C) 2015-2019  Tanguy Fardet
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+""" Tools to analyze graphs with the graph-tool backend """
+
+import scipy.sparse as ssp
+
+
+def global_clustering(g, weights=None):
+    '''
+    Returns the global clustering coefficient.
+
+    Parameters
+    ----------
+    g : :class:`~nngt.Graph`
+        Graph to analyze.
+    weights : bool or str, optional (default: binary edges)
+        Whether edge weights should be considered; if ``None`` or ``False``
+        then use binary edges; if ``True``, uses the 'weight' edge attribute,
+        otherwise uses any valid edge attribute required.
+
+    References
+    ----------
+    .. [ig-global-clustering] https://igraph.org/python/doc/igraph.GraphBase-class.html#transitivity_undirected
+    '''
+    ww = _get_weights(g, weights)
+
+    if ww is not None:
+        # raise warning
+        return np.average(g.graph.transitivity_local_undirected(weights=ww))
+
+    return np.array(g.graph.transitivity_undirected())
+
+
+def local_clustering(g, weights=False, nodes=None):
+    '''
+    Returns the local clustering coefficient of some `nodes`.
+
+    Parameters
+    ----------
+    g : :class:`~nngt.Graph`
+        Graph to analyze.
+    weights : bool or str, optional (default: binary edges)
+        Whether edge weights should be considered; if ``None`` or ``False``
+        then use binary edges; if ``True``, uses the 'weight' edge attribute,
+        otherwise uses any valid edge attribute required.
+    nodes : list, optional (default: all nodes)
+        The list of nodes for which the clutering will be returned
+
+    Returns
+    -------
+    lc : :class:`numpy.ndarray`
+        The list of clustering coefficients, on per node.
+
+    References
+    ----------
+    .. [ig-local-clustering] https://igraph.org/python/doc/igraph.GraphBase-class.html#transitivity_local_undirected
+    '''
+    ww = _get_weights(g, weights)
+
+    return np.array(g.graph.transitivity_local_undirected(nodes, weights=ww))
+
+
+def assortativity(g, degree, weights=None):
+    '''
+    Returns the assortativity of the graph.
+    This tells whether nodes are preferentially connected together depending
+    on their degree.
+
+    Parameters
+    ----------
+    g : :class:`~nngt.Graph`
+        Graph to analyze.
+    degree : str
+        The type of degree that should be considered.
+    weights : bool or str, optional (default: binary edges)
+        Whether edge weights should be considered; if ``None`` or ``False``
+        then use binary edges; if ``True``, uses the 'weight' edge attribute,
+        otherwise uses any valid edge attribute required.
+
+    References
+    ----------
+    .. [gt-assortativity] https://graph-tool.skewed.de/static/doc/correlations.html#graph_tool.correlations.scalar_assortativity
+    '''
+    use_weights = True if weights in (True, 'weight') else False
+
+    if not use_weights:
+        raise RuntimeError("igraph backend does not support specific attributes "
+        "as weights yet, will come soon.")
+
+    degrees = graph.get_degrees(deg_type=deg_type, use_weights=use_weights)
+
+    return g.graph.assortativity(degrees, directed=graph.is_directed())
+
+
+def reciprocity(g):
+    '''
+    Calculate the edge reciprocity of the graph.
+
+    Parameters
+    ----------
+    g : :class:`~nngt.Graph`
+        Graph to analyze.
+
+    References
+    ----------
+    .. [gt-reciprocity] https://graph-tool.skewed.de/static/doc/topology.html#graph_tool.topology.edge_reciprocity
+    '''
+    return edge_reciprocity(g.graph)
+
+
+def closeness(g, weighted=False, nodes=None):
+    '''
+    Returns the closeness centrality of some `nodes`.
+
+    Parameters
+    ----------
+    g : :class:`~nngt.Graph`
+        Graph to analyze.
+    weights : bool or str, optional (default: binary edges)
+        Whether edge weights should be considered; if ``None`` or ``False``
+        then use binary edges; if ``True``, uses the 'weight' edge attribute,
+        otherwise uses any valid edge attribute required.
+    nodes : list, optional (default: all nodes)
+        The list of nodes for which the clutering will be returned
+
+    Returns
+    -------
+    c : :class:`numpy.ndarray`
+        The list of closeness centralities, on per node.
+
+    References
+    ----------
+    .. [ig-closeness] https://igraph.org/python/doc/igraph.GraphBase-class.html#closeness
+    '''
+    ww = _get_weights(g, weights)
+
+    return g.graph.closeness(nodes, mode="out", weights=ww)
+
+
+def connected_components(g, ctype=None):
+    '''
+    Returns the connected component to which each node belongs.
+
+    Parameters
+    ----------
+    g : :class:`~nngt.Graph`
+        Graph to analyze.
+    ctype : str, optional (default 'scc')
+        Type of component that will be searched: either strongly connected
+        ('scc', by default) or weakly connected ('wcc').
+
+    Returns
+    -------
+    cc, hist : :class:`numpy.ndarray`
+        The component associated to each node (`cc`) and the number of nodes in
+        each of the component (`hist`).
+
+    References
+    ----------
+    .. [gt-connected-components] https://graph-tool.skewed.de/static/doc/topology.html#graph_tool.topology.label_components
+    '''
+    cc, hist = label_components(g.graph, *args, **kwargs)
+    return cc.a, hist
+
+
+def diameter(g, weighted=False):
+    '''
+    Returns the pseudo-diameter of the graph.
+
+    Parameters
+    ----------
+    g : :class:`~nngt.Graph`
+        Graph to analyze.
+    weights : bool or str, optional (default: binary edges)
+        Whether edge weights should be considered; if ``None`` or ``False``
+        then use binary edges; if ``True``, uses the 'weight' edge attribute,
+        otherwise uses any valid edge attribute required.
+
+    References
+    ----------
+    .. [gt-diameter] https://graph-tool.skewed.de/static/doc/topology.html#graph_tool.topology.pseudo_diameter
+    '''
+    ww = _get_weights(g, weights)
+
+    return pseudo_diameter(g.graph, weights=ww)
+
+
+def adj_mat(g, weights=None):
+    r'''
+    Returns the adjacency matrix :math:`A` of the graph.
+    With edge :math:`i \leftarrow j` corresponding to entry :math:`A_{ij}`.
+
+    Parameters
+    ----------
+    g : :class:`~nngt.Graph`
+        Graph to analyze.
+    weights : bool or str, optional (default: binary edges)
+        Whether edge weights should be considered; if ``None`` or ``False``
+        then returns the binary adjacency matrix; if ``True``, returns the
+        weighted matrix, otherwise fills the matrix with any valid edge
+        attribute values.
+
+    Note
+    ----
+    This function does not use a builtin igraph method.
+
+    Returns
+    -------
+    The adjacency matrix as a :class:`scipy.sparse.csr_matrix`.
+    '''
+    n = g.node_nb()
+
+    if g.edge_nb():
+        xs, ys = map(np.array, zip(*g.graph.get_edgelist()))
+        xs, ys = xs.T, ys.T
+
+        data = np.ones(xs.shape) * _get_weights(g, weights)
+
+        coo_adj = ssp.coo_matrix((data, (xs, ys)), shape=(n,n))
+
+        return coo_adj.tocsr()
+
+    return ssp.csr_matrix((n,n))
+
+
+def get_edges(g):
+    '''
+    Returns the edges in the graph by order of creation.
+    '''
+    return g.graph.get_edgelist()
+
+
+def _get_weights(g, weights):
+    if weights in g.edges_attributes:
+        # existing edge attribute
+        return np.array(g.graph.es[weights])
+    elif nonstring_container(weights):
+        # user-provided array
+        return np.array(weights)
+    elif weights is True:
+        # "normal" weights
+        return np.array(g.graph.es["weight"])
+    elif not weights:
+        # unweighted
+        return None
+
+    raise ValueError("Unknown edge attribute '" + str(weights) + "'.")
+    

--- a/nngt/analysis/ig_functions.py
+++ b/nngt/analysis/ig_functions.py
@@ -392,17 +392,22 @@ def adj_mat(g, weights=None):
     '''
     n = g.node_nb()
 
+    w = _get_weights(g, weights)
+
     if g.edge_nb():
         xs, ys = map(np.array, zip(*g.graph.get_edgelist()))
         xs, ys = xs.T, ys.T
 
-        data = np.ones(xs.shape) * _get_weights(g, weights)
+        data = np.ones(xs.shape)
 
-        coo_adj = ssp.coo_matrix((data, (xs, ys)), shape=(n,n))
+        if w is not None:
+            data *= w
+
+        coo_adj = ssp.coo_matrix((data, (xs, ys)), shape=(n, n))
 
         return coo_adj.tocsr()
 
-    return ssp.csr_matrix((n,n))
+    return ssp.csr_matrix((n, n))
 
 
 def get_edges(g):

--- a/nngt/analysis/ig_functions.py
+++ b/nngt/analysis/ig_functions.py
@@ -348,14 +348,15 @@ def connected_components(g, ctype=None):
     ----------
     .. [ig-connected-components] https://igraph.org/python/doc/igraph.GraphBase-class.html#clusters
     '''
-    ig_type = 2
+    ctype   = "scc" if ctype is None else ctype
+    ig_type = "strong"
 
     if ctype == "wcc":
-        ig_type = 1
+        ig_type = "weak"
     elif ctype != "scc":
         raise ValueError("`ctype` must be either 'scc' or 'wcc'.")
 
-    clusters = g.graph.clusters()
+    clusters = g.graph.clusters(ig_type)
 
     cc = np.zeros(g.node_nb(), dtype=int)
 

--- a/nngt/analysis/ig_functions.py
+++ b/nngt/analysis/ig_functions.py
@@ -188,9 +188,35 @@ def reciprocity(g):
     return g.graph.reciprocity(ignore_loops=True, mode="default")
 
 
-def closeness(g, weighted=False, nodes=None):
+def closeness(g, weights=None, nodes=None, mode="out", harmonic=False,
+              default=np.NaN):
     '''
     Returns the closeness centrality of some `nodes`.
+
+    Closeness centrality of a node `u` is defined, for the harmonic version,
+    as the sum of the reciprocal of the shortest path distance :math:`d_{uv}`
+    from `u` to the other nodes in its component (if `mode` is "out",
+    reciprocally :math:`d_{vu}`, the distance to `u` from another node v,
+    if `mode` is "in"):
+
+    .. math::
+
+        C(u) = \frac{1}{n - 1} \sum_{v \neq u} \frac{1}{d_{uv}},
+
+    or, using the arithmetic definition, as the reciprocal of the
+    average shortest path distance to/from `u` over to all other nodes:
+
+    .. math::
+
+        C(u) = \frac{n - 1}{\sum_{v \neq u} d_{uv}},
+
+    where `d_{uv}` is the shortest-path distance from `u` to `v`,
+    and `n` is the number of nodes in the graph.
+
+    By definition, the distance is infinite when nodes are not connected by
+    a path in the harmonic case (such that :math:`\frac{1}{d(v, u)} = 0`),
+    while the distance itself is taken as zero for unconnected nodes in the
+    first equation.
 
     Parameters
     ----------
@@ -202,19 +228,43 @@ def closeness(g, weighted=False, nodes=None):
         otherwise uses any valid edge attribute required.
     nodes : list, optional (default: all nodes)
         The list of nodes for which the clutering will be returned
+    mode : str, optional (default: "out")
+        For directed graphs, whether the distances are computed from ("out") or
+        to ("in") each of the nodes.
+    harmonic : bool, optional (default: False)
+        Whether the arithmetic (default) or the harmonic (recommended) version
+        of the closeness should be used.
 
     Returns
     -------
     c : :class:`numpy.ndarray`
         The list of closeness centralities, on per node.
 
+    .. warning ::
+        For compatibility reasons (harmonic closeness is not implemented for
+        igraph), the arithmetic version is used by default; however, it is
+        recommended to use the harmonic version instead whenever possible.
+
+    Note
+    ----
+    When requesting a subset of nodes, check whether it is faster to use
+    `nodes`, or to compute all closeness centralities, then take the subset.
+
     References
     ----------
     .. [ig-closeness] https://igraph.org/python/doc/igraph.GraphBase-class.html#closeness
     '''
+    if harmonic:
+        raise NotImplementedError("`harmonic` closeness is not available with "
+                                  "igraph backend.")
+
     ww = _get_weights(g, weights)
 
-    return g.graph.closeness(nodes, mode="out", weights=ww)
+    if not np.all(g.get_degrees("in")) or not np.all(g.get_degrees("out")):
+        raise RuntimeError("Igraph backend does not support closeness for "
+                           "graphs containing nodes with zero in/out-degree.")
+
+    return g.graph.closeness(nodes, mode=mode, weights=ww)
 
 
 def connected_components(g, ctype=None):

--- a/nngt/analysis/ig_functions.py
+++ b/nngt/analysis/ig_functions.py
@@ -44,7 +44,7 @@ def global_clustering(g, weights=None):
 
     References
     ----------
-    .. [ig-global-clustering] https://igraph.org/python/doc/igraph.GraphBase-class.html#transitivity_undirected
+    .. [ig-global-clustering] :igdoc:`transitivity_undirected`
     '''
     ww = _get_weights(g, weights)
 
@@ -159,7 +159,7 @@ def reciprocity(g):
 
 def closeness(g, weights=None, nodes=None, mode="out", harmonic=False,
               default=np.NaN):
-    '''
+    r'''
     Returns the closeness centrality of some `nodes`.
 
     Closeness centrality of a node `u` is defined, for the harmonic version,

--- a/nngt/analysis/ig_functions.py
+++ b/nngt/analysis/ig_functions.py
@@ -370,7 +370,10 @@ def connected_components(g, ctype=None):
 
 def diameter(g, weights=None):
     '''
-    Returns the pseudo-diameter of the graph.
+    Returns the diameter of the graph.
+
+    It returns infinity if the graph is not connected (strongly connected for
+    directed graphs).
 
     Parameters
     ----------

--- a/nngt/analysis/ig_functions.py
+++ b/nngt/analysis/ig_functions.py
@@ -387,6 +387,11 @@ def diameter(g, weights=None):
     '''
     ww = _get_weights(g, weights)
 
+    mode = "strong" if g.is_directed() else "weak"
+
+    if not g.graph.is_connected(mode):
+        return np.inf
+
     return g.graph.diameter(weights=ww)
 
 

--- a/nngt/analysis/ig_functions.py
+++ b/nngt/analysis/ig_functions.py
@@ -56,37 +56,6 @@ def global_clustering(g, weights=None):
     return np.array(g.graph.as_undirected().transitivity_undirected())
 
 
-def local_clustering(g, weights=None, nodes=None):
-    '''
-    Returns the local clustering coefficient of some `nodes`.
-
-    Parameters
-    ----------
-    g : :class:`~nngt.Graph`
-        Graph to analyze.
-    weights : bool or str, optional (default: binary edges)
-        Whether edge weights should be considered; if ``None`` or ``False``
-        then use binary edges; if ``True``, uses the 'weight' edge attribute,
-        otherwise uses any valid edge attribute required.
-    nodes : list, optional (default: all nodes)
-        The list of nodes for which the clutering will be returned
-
-    Returns
-    -------
-    lc : :class:`numpy.ndarray`
-        The list of clustering coefficients, on per node.
-
-    References
-    ----------
-    .. [ig-local-clustering] https://igraph.org/python/doc/igraph.GraphBase-class.html#transitivity_local_undirected
-    '''
-    if weights is not None and not isinstance(weights, str):
-        raise ValueError("Only existing attributes can be used as weights.")
-
-    return np.array(g.graph.as_undirected().transitivity_local_undirected(
-        nodes, weights=weights))
-
-
 def undirected_local_clustering(g, weights=None, nodes=None,
                                 combine_weights="sum"):
     '''
@@ -126,7 +95,7 @@ def undirected_local_clustering(g, weights=None, nodes=None,
 
     References
     ----------
-    .. [ig-local-clustering] https://igraph.org/python/doc/igraph.GraphBase-class.html#transitivity_local_undirected
+    .. [ig-local-clustering] :igdoc:`transitivity_local_undirected`
     '''
     if weights is not None and not isinstance(weights, str):
         raise ValueError("Only existing attributes can be used as weights.")
@@ -156,7 +125,7 @@ def assortativity(g, degree, weights=None):
 
     References
     ----------
-    .. [ig-assortativity] https://igraph.org/python/doc/igraph.GraphBase-class.html#assortativity
+    .. [ig-assortativity] :igdoc:`assortativity`
     '''
     ww = _get_weights(g, weights)
 
@@ -183,7 +152,7 @@ def reciprocity(g):
 
     References
     ----------
-    .. [ig-reciprocity] https://igraph.org/python/doc/igraph.GraphBase-class.html#reciprocity
+    .. [ig-reciprocity] :igdoc:`reciprocity`
     '''
     return g.graph.reciprocity(ignore_loops=True, mode="default")
 

--- a/nngt/analysis/ig_functions.py
+++ b/nngt/analysis/ig_functions.py
@@ -221,7 +221,7 @@ def closeness(g, weights=None, nodes=None, mode="out", harmonic=False,
 
     References
     ----------
-    .. [ig-closeness] https://igraph.org/python/doc/igraph.GraphBase-class.html#closeness
+    .. [ig-closeness] :igdoc:`closeness`
     '''
     if harmonic:
         raise NotImplementedError("`harmonic` closeness is not available with "
@@ -261,8 +261,8 @@ def betweenness(g, btype="both", weights=None):
 
     References
     ----------
-    .. [ig-ebetw] https://igraph.org/python/doc/igraph.GraphBase-class.html#edge_betweenness
-    .. [ig-nbetw] https://igraph.org/python/doc/igraph.GraphBase-class.html#betweenness
+    .. [ig-ebetw] :igdoc:`edge_betweenness`
+    .. [ig-nbetw] :igdoc:`betweenness`
     '''
     w = _get_weights(g, weights)
 
@@ -315,7 +315,7 @@ def connected_components(g, ctype=None):
 
     References
     ----------
-    .. [ig-connected-components] https://igraph.org/python/doc/igraph.GraphBase-class.html#clusters
+    .. [ig-connected-components] :igdoc:`clusters`
     '''
     ctype   = "scc" if ctype is None else ctype
     ig_type = "strong"
@@ -355,7 +355,7 @@ def diameter(g, weights=None):
 
     References
     ----------
-    .. [ig-diameter] https://igraph.org/python/doc/igraph.GraphBase-class.html#diameter
+    .. [ig-diameter] :igdoc:`diameter`
     '''
     ww = _get_weights(g, weights)
 

--- a/nngt/analysis/ig_functions.py
+++ b/nngt/analysis/ig_functions.py
@@ -158,20 +158,23 @@ def assortativity(g, degree, weights=None):
     ----------
     .. [ig-assortativity] https://igraph.org/python/doc/igraph.GraphBase-class.html#assortativity
     '''
-    use_weights = True if weights in (True, 'weight') else False
+    ww = _get_weights(g, weights)
 
-    if not use_weights:
-        raise RuntimeError("igraph backend does not support specific "
-        "attributes as weights yet, will come soon.")
+    node_attr = g.get_degrees(degree, use_weights=ww)
 
-    degrees = graph.get_degrees(deg_type=deg_type, use_weights=use_weights)
-
-    return g.graph.assortativity(degrees, directed=graph.is_directed())
+    return g.graph.assortativity(node_attr, directed=g.is_directed())
 
 
 def reciprocity(g):
     '''
     Calculate the edge reciprocity of the graph.
+
+    The reciprocity is defined as the number of edges that have a reciprocal
+    edge (an edge between the same nodes but in the opposite direction)
+    divided by the total number of edges.
+    This is also the probability for any given edge, that its reciprocal edge
+    exists.
+    By definition, the reciprocity of undirected graphs is 1.
 
     Parameters
     ----------

--- a/nngt/analysis/ig_functions.py
+++ b/nngt/analysis/ig_functions.py
@@ -29,7 +29,9 @@ from ..lib.test_functions import nonstring_container
 
 def global_clustering(g, weights=None):
     '''
-    Returns the global clustering coefficient.
+    Returns the undirected global clustering coefficient.
+    This corresponds to the ratio of undirected triangles to the number of
+    undirected triads.
 
     Parameters
     ----------
@@ -83,6 +85,56 @@ def local_clustering(g, weights=None, nodes=None):
 
     return np.array(g.graph.as_undirected().transitivity_local_undirected(
         nodes, weights=weights))
+
+
+def undirected_local_clustering(g, weights=None, nodes=None,
+                                combine_weights="sum"):
+    '''
+    Returns the local clustering coefficient of some `nodes`.
+
+    Parameters
+    ----------
+    g : :class:`~nngt.Graph`
+        Graph to analyze.
+    weights : bool or str, optional (default: binary edges)
+        Whether edge weights should be considered; if ``None`` or ``False``
+        then use binary edges; if ``True``, uses the 'weight' edge attribute,
+        otherwise uses any valid edge attribute required.
+    nodes : list, optional (default: all nodes)
+        The list of nodes for which the clutering will be returned
+    combine_weights : str, optional (default: "sum")
+        How the weights of directed edges between two nodes should be combined,
+        among:
+
+        * "sum": the sum of the edge attribute values will be used for the new
+          edge.
+        * "product": the product of the edge attribute values will be used for
+          the new edge.
+        * "mean": the mean of the edge attribute values will be used for the
+          new edge.
+        * "median": the median of the edge attribute values will be used for
+          the new edge.
+        * "min": the minimum of the edge attribute values will be used for the
+          new edge.
+        * "max": the maximum of the edge attribute values will be used for the
+          new edge. 
+
+    Returns
+    -------
+    lc : :class:`numpy.ndarray`
+        The list of clustering coefficients, on per node.
+
+    References
+    ----------
+    .. [ig-local-clustering] https://igraph.org/python/doc/igraph.GraphBase-class.html#transitivity_local_undirected
+    '''
+    if weights is not None and not isinstance(weights, str):
+        raise ValueError("Only existing attributes can be used as weights.")
+
+    u = g.graph.as_undirected(combine_edges=combine_weights)
+    u.simplify()
+
+    return np.array(u.transitivity_local_undirected(nodes, weights=weights))
 
 
 def assortativity(g, degree, weights=None):

--- a/nngt/analysis/nx_functions.py
+++ b/nngt/analysis/nx_functions.py
@@ -52,7 +52,6 @@ def global_clustering(g, weights=None):
     References
     ----------
     .. [nx-global-clustering] https://networkx.github.io/documentation/stable/reference/algorithms/generated/networkx.algorithms.cluster.transitivity.html
-    .. [nx-average-clustering] https://networkx.github.io/documentation/stable/reference/algorithms/generated/networkx.algorithms.cluster.average_clustering.html
     '''
     w = _get_weights(g, weights)
 
@@ -61,38 +60,6 @@ def global_clustering(g, weights=None):
 
     raise NotImplementedError("Weighted global clustering is not implemented "
                               "for networkx backend.")
-
-
-def local_clustering(g, weights=None, nodes=None):
-    '''
-    Returns the local clustering coefficient of some `nodes`.
-
-    Parameters
-    ----------
-    g : :class:`~nngt.Graph`
-        Graph to analyze.
-    weights : bool or str, optional (default: binary edges)
-        Whether edge weights should be considered; if ``None`` or ``False``
-        then use binary edges; if ``True``, uses the 'weight' edge attribute,
-        otherwise uses any valid edge attribute required.
-    nodes : list, optional (default: all nodes)
-        The list of nodes for which the clutering will be returned
-
-    Returns
-    -------
-    lc : :class:`numpy.ndarray`
-        The list of clustering coefficients, on per node.
-
-    References
-    ----------
-    .. [nx-local-clustering] https://networkx.github.io/documentation/stable/reference/algorithms/generated/networkx.algorithms.cluster.clustering.html
-    '''
-    ww = _get_weights(g, weights)
-
-    lc = nx.clustering(g.graph.to_undirected(as_view=True), nodes=nodes, weight=weights)
-    lc = np.array([lc[i] for i in range(g.node_nb())], dtype=float)
-
-    return lc
 
 
 def undirected_local_clustering(g, weights=None, nodes=None,
@@ -137,7 +104,7 @@ def undirected_local_clustering(g, weights=None, nodes=None,
 
     References
     ----------
-    .. [nx-local-clustering] https://networkx.github.io/documentation/stable/reference/algorithms/generated/networkx.algorithms.cluster.clustering.html
+    .. [nx-local-clustering] :nxdoc:`algorithms.cluster.clustering`
     '''
     ww = _get_weights(g, weights)
 
@@ -173,7 +140,8 @@ def assortativity(g, degree, weights=None):
 
     References
     ----------
-    .. [nx-assortativity] https://networkx.github.io/documentation/stable/reference/algorithms/generated/networkx.algorithms.assortativity.degree_assortativity_coefficient.html
+    .. [nx-assortativity]
+       :nxdoc:`algorithms.assortativity.degree_assortativity_coefficient`
     '''
     if weights is not None:
         raise NotImplementedError("Weighted assortatibity is not yet "
@@ -205,7 +173,7 @@ def reciprocity(g):
 
     References
     ----------
-    .. [nx-reciprocity] https://networkx.github.io/documentation/stable/reference/algorithms/generated/networkx.algorithms.reciprocity.overall_reciprocity.html
+    .. [nx-reciprocity] :nxdoc:`algorithms.reciprocity.overall_reciprocity`
     '''
     if not g.is_directed():
         return 1.
@@ -311,7 +279,7 @@ def betweenness(g, btype="both", weights=None):
     ----------
     g : :class:`~nngt.Graph`
         Graph to analyze.
-    ctype : str, optional (default 'both')
+    btype : str, optional (default 'both')
         The centrality that should be returned (either 'node', 'edge', or
         'both'). By default, both betweenness centralities are computed.
     weights : bool or str, optional (default: binary edges)

--- a/nngt/analysis/nx_functions.py
+++ b/nngt/analysis/nx_functions.py
@@ -224,13 +224,13 @@ def closeness(g, weights=None, nodes=None, mode="out", harmonic=False,
 
     Closeness centrality of a node `u` is defined, for the harmonic version,
     as the sum of the reciprocal of the shortest path distance :math:`d_{uv}`
-    from `u` to the other nodes in its component (if `mode` is "out",
+    from `u` to the N - 1 other nodes in the graph (if `mode` is "out",
     reciprocally :math:`d_{vu}`, the distance to `u` from another node v,
     if `mode` is "in"):
 
     .. math::
 
-        C(u) = \frac{1}{n - 1} \sum_{v \neq u} \frac{1}{d_{uv}},
+        C(u) = \frac{1}{N - 1} \sum_{v \neq u} \frac{1}{d_{uv}},
 
     or, using the arithmetic definition, as the reciprocal of the
     average shortest path distance to/from `u` over to all other nodes:
@@ -240,7 +240,7 @@ def closeness(g, weights=None, nodes=None, mode="out", harmonic=False,
         C(u) = \frac{n - 1}{\sum_{v \neq u} d_{uv}},
 
     where `d_{uv}` is the shortest-path distance from `u` to `v`,
-    and `n` is the number of nodes in the graph.
+    and `n` is the number of nodes in the component.
 
     By definition, the distance is infinite when nodes are not connected by
     a path in the harmonic case (such that :math:`\frac{1}{d(v, u)} = 0`),
@@ -305,6 +305,54 @@ def closeness(g, weights=None, nodes=None, mode="out", harmonic=False,
         return c
 
     return c[nodes]
+
+
+def betweenness(g, btype="both", weights=None):
+    '''
+    Returns the normalized betweenness centrality of the nodes and edges.
+
+    Parameters
+    ----------
+    g : :class:`~nngt.Graph`
+        Graph to analyze.
+    ctype : str, optional (default 'both')
+        The centrality that should be returned (either 'node', 'edge', or
+        'both'). By default, both betweenness centralities are computed.
+    weights : bool or str, optional (default: binary edges)
+        Whether edge weights should be considered; if ``None`` or ``False``
+        then use binary edges; if ``True``, uses the 'weight' edge attribute,
+        otherwise uses any valid edge attribute required.
+
+    Returns
+    -------
+    nb : :class:`numpy.ndarray`
+        The nodes' betweenness if `btype` is 'node' or 'both'
+    eb : :class:`numpy.ndarray`
+        The edges' betweenness if `btype` is 'edge' or 'both'
+
+    References
+    ----------
+    .. [nx-ebetw] https://networkx.github.io/documentation/stable/reference/algorithms/generated/networkx.algorithms.centrality.edge_betweenness_centrality.html#networkx.algorithms.centrality.edge_betweenness_centrality
+    .. [nx-nbetw] https://networkx.github.io/documentation/stable/reference/algorithms/generated/networkx.algorithms.centrality.betweenness_centrality.html#networkx.algorithms.centrality.betweenness_centrality
+    '''
+    w = _get_weights(g, weights)
+
+    nb, eb = None, None
+
+    if btype in ("both", "node"):
+        di_nb = nx.betweenness_centrality(g.graph, weight=w)
+        nb    = np.array([di_nb[i] for i in g.get_nodes()])
+
+    if btype in ("both", "edge"):
+        di_eb = nx.edge_betweenness_centrality(g.graph, weight=w)
+        eb    = np.array([di_eb[tuple(e)] for e in g.edges_array])
+
+    if btype == "node":
+        return nb
+    elif btype == "edge":
+        return eb
+
+    return nb, eb
 
 
 def connected_components(g, ctype=None):

--- a/nngt/analysis/nx_functions.py
+++ b/nngt/analysis/nx_functions.py
@@ -377,12 +377,15 @@ def connected_components(g, ctype=None):
 
     References
     ----------
-    .. [nx-scc] 
-    .. [nx-wcc] 
+    .. [nx-scc] https://networkx.github.io/documentation/stable/reference/algorithms/generated/networkx.algorithms.components.strongly_connected_components.html#networkx.algorithms.components.strongly_connected_components
+    .. [nx-wcc] https://networkx.github.io/documentation/stable/reference/algorithms/generated/networkx.algorithms.components.weakly_connected_components.html#networkx.algorithms.components.weakly_connected_components
     '''
-    res = None
+    ctype = "scc" if ctype is None else ctype
+    res   = None
 
-    if ctype == "scc":
+    if not g.is_directed():
+        res = nx.connected_components(g.graph)
+    elif ctype == "scc":
         res = nx.strongly_connected_components(g.graph)
     elif ctype == "wcc":
         res = nx.weakly_connected_components(g.graph)

--- a/nngt/analysis/nx_functions.py
+++ b/nngt/analysis/nx_functions.py
@@ -34,7 +34,9 @@ from networkx.algorithms import (strongly_connected_components,
 
 def global_clustering(g, weights=None):
     '''
-    Returns the global clustering coefficient.
+    Returns the undirected global clustering coefficient.
+    This corresponds to the ratio of undirected triangles to the number of
+    undirected triads.
 
     Parameters
     ----------
@@ -59,9 +61,10 @@ def global_clustering(g, weights=None):
     w = _get_weights(g, weights)
 
     if w is None:
-        return nx.transitivity(g.graph)
+        return nx.transitivity(g.graph.to_undirected(as_view=True))
 
-    return np.average(nx.clustering(g.graph, weight=weights))
+    raise NotImplementedError("Weighted global clustering is not implemented "
+                              "for networkx backend.")
 
 
 def local_clustering(g, weights=None, nodes=None):
@@ -90,7 +93,66 @@ def local_clustering(g, weights=None, nodes=None):
     '''
     ww = _get_weights(g, weights)
 
-    lc = nx.clustering(nx.to_undirected(g.graph), nodes=nodes, weight=weights)
+    lc = nx.clustering(g.graph.to_undirected(as_view=True), nodes=nodes, weight=weights)
+    lc = np.array([lc[i] for i in range(g.node_nb())], dtype=float)
+
+    return lc
+
+
+def undirected_local_clustering(g, weights=None, nodes=None,
+                                combine_weights="sum"):
+    '''
+    Returns the undirected local clustering coefficient of some `nodes`.
+
+    If `g` is directed, then it is converted to a simple undirected graph
+    (no parallel edges).
+
+    Parameters
+    ----------
+    g : :class:`~nngt.Graph`
+        Graph to analyze.
+    weights : bool or str, optional (default: binary edges)
+        Whether edge weights should be considered; if ``None`` or ``False``
+        then use binary edges; if ``True``, uses the 'weight' edge attribute,
+        otherwise uses any valid edge attribute required.
+    nodes : list, optional (default: all nodes)
+        The list of nodes for which the clutering will be returned
+    combine_weights : str, optional (default: "sum")
+        How the weights of directed edges between two nodes should be combined,
+        among:
+
+        * "sum": the sum of the edge attribute values will be used for the new
+          edge.
+        * "product": the product of the edge attribute values will be used for
+          the new edge.
+        * "mean": the mean of the edge attribute values will be used for the
+          new edge.
+        * "median": the median of the edge attribute values will be used for
+          the new edge.
+        * "min": the minimum of the edge attribute values will be used for the
+          new edge.
+        * "max": the maximum of the edge attribute values will be used for the
+          new edge. 
+
+    Returns
+    -------
+    lc : :class:`numpy.ndarray`
+        The list of clustering coefficients, on per node.
+
+    References
+    ----------
+    .. [nx-local-clustering] https://networkx.github.io/documentation/stable/reference/algorithms/generated/networkx.algorithms.cluster.clustering.html
+    '''
+    ww = _get_weights(g, weights)
+
+    if g.is_directed() and ww is not None:
+        raise NotImplementedError("networkx backend currently does not "
+                                  "provide weighted clustering for directed "
+                                  "graphs.")
+
+    lc = nx.clustering(g.graph.to_undirected(as_view=True), nodes=nodes,
+                       weight=weights)
+       
     lc = np.array([lc[i] for i in range(g.node_nb())], dtype=float)
 
     return lc

--- a/nngt/analysis/nx_functions.py
+++ b/nngt/analysis/nx_functions.py
@@ -377,15 +377,15 @@ def connected_components(g, ctype=None):
 
     References
     ----------
-    .. [nx-scc] https://graph-tool.skewed.de/static/doc/topology.html#graph_tool.topology.label_components
-    .. [nx-wcc]
+    .. [nx-scc] 
+    .. [nx-wcc] 
     '''
     res = None
 
     if ctype == "scc":
-        res = strongly_connected_components(g.graph)
+        res = nx.strongly_connected_components(g.graph)
     elif ctype == "wcc":
-        res = weakly_connected_components(g.graph)
+        res = nx.weakly_connected_components(g.graph)
     else:
         raise ValueError("Invalid `ctype`, only 'scc' and 'wcc' are allowed.")
 
@@ -393,7 +393,7 @@ def connected_components(g, ctype=None):
     hist = []
 
     for i, nodes in enumerate(res):
-        cc[nodes] = i
+        cc[list(nodes)] = i
 
         hist.append(len(nodes))
 

--- a/nngt/analysis/nx_functions.py
+++ b/nngt/analysis/nx_functions.py
@@ -26,10 +26,6 @@ import numpy as np
 from ..lib.test_functions import nonstring_container
 
 import networkx as nx
-from networkx.algorithms import diameter as nx_diam
-from networkx.algorithms import (strongly_connected_components,
-                                 weakly_connected_components,
-                                 degree_assortativity_coefficient)
 
 
 def global_clustering(g, weights=None):
@@ -185,8 +181,8 @@ def assortativity(g, degree, weights=None):
 
     w = _get_weights(g, weights)
 
-    return degree_assortativity_coefficient(g.graph, x=degree, y=degree,
-                                            weight=w)
+    return nx.degree_assortativity_coefficient(g.graph, x=degree, y=degree,
+                                               weight=w)
 
 
 def reciprocity(g):
@@ -405,10 +401,10 @@ def connected_components(g, ctype=None):
 
 def diameter(g, weights=False):
     '''
-    Returns the pseudo-diameter of the graph.
+    Returns the diameter of the graph.
 
-    @todo: check what happens if some nodes are disconnected (with and
-    without weights)
+    It returns infinity if the graph is not connected (strongly connected for
+    directed graphs).
 
     Parameters
     ----------
@@ -425,9 +421,18 @@ def diameter(g, weights=False):
     '''
     w = _get_weights(g, weights)
 
+    num_nodes = g.node_nb()
+
     if w is not None:
-        raise NotImplementedError("Weighted diameter is not available for "
-                                  "networkx backend.")
+        res = []
+
+        for _, (d, _) in nx.all_pairs_dijkstra(g.graph, weight=w):
+            if len(d) < num_nodes:
+                return np.inf
+
+            res.extend(d.values())
+
+        return np.max(res)
 
     try:
         return nx.diameter(g.graph)

--- a/nngt/analysis/nx_functions.py
+++ b/nngt/analysis/nx_functions.py
@@ -51,7 +51,7 @@ def global_clustering(g, weights=None):
 
     References
     ----------
-    .. [nx-global-clustering] https://networkx.github.io/documentation/stable/reference/algorithms/generated/networkx.algorithms.cluster.transitivity.html
+    .. [nx-global-clustering] :nxdoc:`algorithms.cluster.transitivity`
     '''
     w = _get_weights(g, weights)
 
@@ -183,7 +183,7 @@ def reciprocity(g):
 
 def closeness(g, weights=None, nodes=None, mode="out", harmonic=False,
               default=np.NaN):
-    '''
+    r'''
     Returns the closeness centrality of some `nodes`.
 
     Closeness centrality of a node `u` is defined, for the harmonic version,

--- a/nngt/analysis/nx_functions.py
+++ b/nngt/analysis/nx_functions.py
@@ -240,8 +240,8 @@ def closeness(g, weights=None, nodes=None, mode="out", harmonic=False,
 
     References
     ----------
-    .. [nx-harmonic] https://networkx.github.io/documentation/stable/reference/algorithms/generated/networkx.algorithms.centrality.harmonic_centrality.html
-    .. [nx-closeness] https://networkx.github.io/documentation/stable/reference/algorithms/generated/networkx.algorithms.centrality.closeness_centrality.html
+    .. [nx-harmonic] :nxdoc:`algorithms.centrality.harmonic_centrality`
+    .. [nx-closeness] :nxdoc:`algorithms.centrality.closeness_centrality`
     '''
     w = _get_weights(g, weights)
 
@@ -296,8 +296,8 @@ def betweenness(g, btype="both", weights=None):
 
     References
     ----------
-    .. [nx-ebetw] https://networkx.github.io/documentation/stable/reference/algorithms/generated/networkx.algorithms.centrality.edge_betweenness_centrality.html#networkx.algorithms.centrality.edge_betweenness_centrality
-    .. [nx-nbetw] https://networkx.github.io/documentation/stable/reference/algorithms/generated/networkx.algorithms.centrality.betweenness_centrality.html#networkx.algorithms.centrality.betweenness_centrality
+    .. [nx-ebetw] :nxdoc:`algorithms.centrality.edge_betweenness_centrality`
+    .. [nx-nbetw] :nxdoc:`networkx.algorithms.centrality.betweenness_centrality`
     '''
     w = _get_weights(g, weights)
 
@@ -323,8 +323,6 @@ def connected_components(g, ctype=None):
     '''
     Returns the connected component to which each node belongs.
 
-    @todo: check if the components are labeled from 0.
-
     Parameters
     ----------
     g : :class:`~nngt.Graph`
@@ -341,8 +339,9 @@ def connected_components(g, ctype=None):
 
     References
     ----------
-    .. [nx-scc] https://networkx.github.io/documentation/stable/reference/algorithms/generated/networkx.algorithms.components.strongly_connected_components.html#networkx.algorithms.components.strongly_connected_components
-    .. [nx-wcc] https://networkx.github.io/documentation/stable/reference/algorithms/generated/networkx.algorithms.components.weakly_connected_components.html#networkx.algorithms.components.weakly_connected_components
+    .. [nx-ucc] :nxdoc:`algorithms.components.connected_components`
+    .. [nx-scc] :nxdoc:`algorithms.components.strongly_connected_components`
+    .. [nx-wcc] :nxdoc:`algorithms.components.weakly_connected_components`
     '''
     ctype = "scc" if ctype is None else ctype
     res   = None
@@ -374,6 +373,9 @@ def diameter(g, weights=False):
     It returns infinity if the graph is not connected (strongly connected for
     directed graphs).
 
+    For weighted graphs, uses the Dijkstra algorithm to find all shortests
+    paths and returns the longest.
+
     Parameters
     ----------
     g : :class:`~nngt.Graph`
@@ -385,7 +387,8 @@ def diameter(g, weights=False):
 
     References
     ----------
-    .. [nx-diameter] https://networkx.github.io/documentation/stable/reference/algorithms/generated/networkx.algorithms.distance_measures.diameter.html
+    .. [nx-diameter] :nxdoc:`algorithms.distance_measures.diameter`
+    .. [nx-dijkstra] :nxdoc:`algorithms.shortest_paths.weighted.all_pairs_dijkstra`
     '''
     w = _get_weights(g, weights)
 
@@ -429,7 +432,7 @@ def adj_mat(g, weights=None):
 
     References
     ----------
-    .. [gt-adjacency] https://graph-tool.skewed.de/static/doc/spectral.html#graph_tool.spectral.adjacency
+    .. [nx-adjacency] :nxdoc:`.convert_matrix.to_scipy_sparse_matrix`
     '''
     w = _get_weights(g, weights)
 

--- a/nngt/analysis/nx_functions.py
+++ b/nngt/analysis/nx_functions.py
@@ -429,7 +429,10 @@ def diameter(g, weights=False):
         raise NotImplementedError("Weighted diameter is not available for "
                                   "networkx backend.")
 
-    return nx.diameter(g.graph)[0]
+    try:
+        return nx.diameter(g.graph)
+    except nx.exception.NetworkXError:
+        return np.inf
 
 
 def adj_mat(g, weights=None):

--- a/nngt/analysis/nx_functions.py
+++ b/nngt/analysis/nx_functions.py
@@ -179,6 +179,10 @@ def assortativity(g, degree, weights=None):
     ----------
     .. [nx-assortativity] https://networkx.github.io/documentation/stable/reference/algorithms/generated/networkx.algorithms.assortativity.degree_assortativity_coefficient.html
     '''
+    if weights is not None:
+        raise NotImplementedError("Weighted assortatibity is not yet "
+                                  "implemented for networkx backend.")
+
     w = _get_weights(g, weights)
 
     return degree_assortativity_coefficient(g.graph, x=degree, y=degree,
@@ -188,6 +192,13 @@ def assortativity(g, degree, weights=None):
 def reciprocity(g):
     '''
     Calculate the edge reciprocity of the graph.
+
+    The reciprocity is defined as the number of edges that have a reciprocal
+    edge (an edge between the same nodes but in the opposite direction)
+    divided by the total number of edges.
+    This is also the probability for any given edge, that its reciprocal edge
+    exists.
+    By definition, the reciprocity of undirected graphs is 1.
 
     @todo: check whether we can get this for single nodes for all libraries.
 
@@ -200,6 +211,9 @@ def reciprocity(g):
     ----------
     .. [nx-reciprocity] https://networkx.github.io/documentation/stable/reference/algorithms/generated/networkx.algorithms.reciprocity.overall_reciprocity.html
     '''
+    if not g.is_directed():
+        return 1.
+
     return nx.overall_reciprocity(g.graph)
 
 

--- a/nngt/core/graph.py
+++ b/nngt/core/graph.py
@@ -820,9 +820,6 @@ class Graph(nngt.core.GraphObject):
         '''
         Degree sequence of all the nodes.
 
-        .. versionchanged:: 0.9
-            Added `syn_type` keyword.
-
         Parameters
         ----------
         deg_type : string, optional (default: "total")

--- a/nngt/core/graph.py
+++ b/nngt/core/graph.py
@@ -886,28 +886,35 @@ class Graph(nngt.core.GraphObject):
         else:
             raise InvalidArgument("Invalid degree type '{}'".format(deg_type))
 
-    def get_betweenness(self, btype="both", use_weights=False):
+    def get_betweenness(self, btype="both", weights=None):
         '''
-        Betweenness centrality sequence of all nodes and edges.
-
-        @todo add node/edge list
+        Returns the normalized betweenness centrality of the nodes and edges.
 
         Parameters
         ----------
-        btype : str, optional (default: ``"both"``)
-            Type of betweenness to return (``"edge"``, ``"node"``-betweenness,
-            or ``"both"``).
-        use_weights : bool, optional (default: False)
-            Whether to use weighted (True) or simple degrees (False).
+        g : :class:`~nngt.Graph`
+            Graph to analyze.
+        btype : str, optional (default 'both')
+            The centrality that should be returned (either 'node', 'edge', or
+            'both'). By default, both betweenness centralities are computed.
+        weights : bool or str, optional (default: binary edges)
+            Whether edge weights should be considered; if ``None`` or
+            ``False`` then use binary edges; if ``True``, uses the 'weight'
+            edge attribute, otherwise uses any valid edge attribute required.
 
         Returns
         -------
-        node_betweenness : :class:`numpy.array`
-            Betweenness of the nodes (if `btype` is ``"node"`` or ``"both"``).
-        edge_betweenness : :class:`numpy.array`
-            Betweenness of the edges (if `btype` is ``"edge"`` or ``"both"``).
+        nb : :class:`numpy.ndarray`
+            The nodes' betweenness if `btype` is 'node' or 'both'
+        eb : :class:`numpy.ndarray`
+            The edges' betweenness if `btype` is 'edge' or 'both'
+
+        See also
+        --------
+        :func:`~nngt.analysis.betweenness`
         '''
-        return self.betweenness_list(btype=btype, use_weights=use_weights)
+        from nngt.analysis import betweenness
+        return betweenness(self, btype=btype, weights=weights)
 
     def get_edge_types(self, edges=None):
         '''

--- a/nngt/core/graph.py
+++ b/nngt/core/graph.py
@@ -805,7 +805,7 @@ class Graph(nngt.core.GraphObject):
         Density of the graph: :math:`\\frac{E}{N^2}`, where `E` is the number
         of edges and `N` the number of nodes.
         '''
-        return self.edge_nb()/float(self.node_nb()**2)
+        return self.edge_nb() / self.node_nb()**2
 
     def is_weighted(self):
         ''' Whether the edges have weights '''
@@ -814,6 +814,22 @@ class Graph(nngt.core.GraphObject):
     def is_directed(self):
         ''' Whether the graph is directed or not '''
         return self._graph.is_directed()
+
+    def is_connected(self, mode="strong"):
+        '''
+        Return whether the graph is connected.
+
+        Parameters
+        ----------
+        mode : str, optional (default: "strong")
+            Whether to test connectedness with directed ("strong") or
+            undirected ("weak") connections.
+
+        References
+        ----------
+        .. [ig-connected] :igdoc:`is_connected`
+        '''
+        return super().is_connected()
 
     def get_degrees(self, deg_type="total", node_list=None, use_weights=False,
                     syn_type="all"):

--- a/nngt/core/graph.py
+++ b/nngt/core/graph.py
@@ -432,8 +432,8 @@ class Graph(nngt.core.GraphObject):
         Returns a deepcopy of the current :class:`~nngt.Graph`
         instance
         '''
-        gc_instance = Graph(name=self._name + '_copy', weighted=self._weighted,
-                            copy_graph=self)
+        gc_instance = Graph(name=self._name + '_copy',
+                            weighted=self.is_weighted(), copy_graph=self)
 
         if self.is_spatial():
             nngt.SpatialGraph.make_spatial(

--- a/nngt/core/graph.py
+++ b/nngt/core/graph.py
@@ -388,8 +388,8 @@ class Graph(nngt.core.GraphObject):
 
     def __repr__(self):
         ''' Provide unambiguous informations regarding the object. '''
-        d = "directed" if self._directed else "undirected"
-        w = "weighted" if self._weighted else "binary"
+        d = "directed" if self.is_directed() else "undirected"
+        w = "weighted" if self.is_weighted() else "binary"
         t = self.type
         n = self.node_nb()
         e = self.edge_nb()
@@ -813,7 +813,7 @@ class Graph(nngt.core.GraphObject):
 
     def is_directed(self):
         ''' Whether the graph is directed or not '''
-        return self._directed
+        return self._graph.is_directed()
 
     def get_degrees(self, deg_type="total", node_list=None, use_weights=False,
                     syn_type="all"):

--- a/nngt/core/graph_datastruct.py
+++ b/nngt/core/graph_datastruct.py
@@ -672,11 +672,11 @@ class NeuralPop(OrderedDict):
 
         neuron_param = {} if neuron_param is None else neuron_param.copy()
 
-        group        = NeuralGroup(neurons, neuron_type=neuron_type,
-                                   neuron_model=neuron_model,
-                                   neuron_param=neuron_param, name=name)
+        group = NeuralGroup(neurons, neuron_type=neuron_type,
+                            neuron_model=neuron_model,
+                            neuron_param=neuron_param, name=name)
 
-        self[name]   = group
+        self[name] = group
 
     def create_meta_group(self, neurons, name, neuron_param=None,
                           replace=False):
@@ -1055,12 +1055,6 @@ class NeuralGroup:
             neuron_type = kwargs["neuron_type"]
         elif len(args) > 1 and is_integer(args[1]):
             neuron_type = arg[1]
-        elif cls == NeuralGroup:
-            neuron_type = 1
-            _log_message(logger, "WARNING",
-                "In version 2.0, default behavior for NeuralGroup will "
-                "change: if `neuron_type` is not provided then it will "
-                "be set to None and a MetaGroup will be generated.")
 
         if neuron_type is None:
             # will need to remove all but nodes and name from args

--- a/nngt/core/graph_datastruct.py
+++ b/nngt/core/graph_datastruct.py
@@ -984,7 +984,8 @@ class NeuralPop(OrderedDict):
             raise AttributeError(
                 "This NeuralPop requires group to have a model attribute that "
                 "is not `None`; to disable this, use `set_model(None)` "
-                "method on this NeuralPop instance.")
+                "method on this NeuralPop instance or set `with_models` to "
+                "False when creating it.")
         elif group.has_model and not self._has_models:
             _log_message(logger, "WARNING",
                          "This NeuralPop is not set to take models into "

--- a/nngt/core/graph_interface.py
+++ b/nngt/core/graph_interface.py
@@ -142,11 +142,7 @@ class GraphInterface:
         pass
 
     @abstractmethod
-    def degree_list(self, node_list=None, deg_type="total", use_weights=True):
-        pass
-
-    @abstractmethod
-    def betweenness_list(self, use_weights=True, as_prop=False, norm=True):
+    def degree_list(self, node_list=None, deg_type="total", use_weights=False):
         pass
 
     @abstractmethod

--- a/nngt/core/gt_graph.py
+++ b/nngt/core/gt_graph.py
@@ -312,9 +312,17 @@ class _GtGraph(GraphInterface):
         g = copy_graph.graph if copy_graph is not None else None
 
         if g is not None:
+            from graph_tool.stats import remove_parallel_edges
+            if not directed and g.is_directed():
+                g = g.copy()
+                g.set_directed(False)
+                remove_parallel_edges(g)
+            elif directed and not g.is_directed():
+                g.set_directed(True)
+
             self._from_library_graph(g, copy=True)
         else:
-            self._graph = nngt._config["graph"](directed=True)
+            self._graph = nngt._config["graph"](directed=directed)
 
             if nodes:
                 self._graph.add_vertex(nodes)
@@ -485,10 +493,6 @@ class _GtGraph(GraphInterface):
             g.add_edge(source, target, add_missing=True)
             # set the attributes
             self._attr_new_edges([(source, target)], attributes=attributes)
-            if not self._directed:
-                c2 = g.add_edge(target, source)
-                # set the attributes
-                self._attr_new_edges([(target, source)], attributes=attributes)
         else:
             if not ignore:
                 raise InvalidArgument("Trying to add existing edge.")
@@ -560,27 +564,8 @@ class _GtGraph(GraphInterface):
             edge_list = np.array(edge_list)
             new_attr = attributes
 
-        if not self._directed:
-            recip_edges = edge_list[:,::-1]
-            # slow but works
-            unique = ~(recip_edges[..., np.newaxis]
-                       == edge_list[..., np.newaxis].T).all(1).any(1)
-            edge_list = np.concatenate((edge_list, recip_edges[unique]))
-
-            for key, val in new_attr.items():
-                new_attr[key] = np.concatenate((val, val[unique]))
-
         # create the edges
         if len(edge_list):
-            if not self._directed:
-                recip_edges = edge_list[:,::-1]
-                # slow but works
-                unique = ~(recip_edges[..., np.newaxis]
-                           == edge_list[..., np.newaxis].T).all(1).any(1)
-                edge_list = np.concatenate((edge_list, recip_edges[unique]))
-                for key, val in new_attr.items():
-                    new_attr[key] = np.concatenate((val, val[unique]))
-
             self._graph.add_edge_list(edge_list)
 
             # call parent function to set the attributes

--- a/nngt/core/gt_graph.py
+++ b/nngt/core/gt_graph.py
@@ -640,6 +640,25 @@ class _GtGraph(GraphInterface):
                 else:
                     return np.array([])
 
+    def is_connected(self, mode="strong"):
+        '''
+        Return whether the graph is connected.
+
+        Parameters
+        ----------
+        mode : str, optional (default: "strong")
+            Whether to test connectedness with directed ("strong") or
+            undirected ("weak") connections.
+        '''
+        from graph_tool.topology import label_components
+
+        directed  = True if mode == "strong" else False
+        directed *= self._graph.is_directed()
+
+        _, hist = label_components(self._graph, directed=directed)
+
+        return len(hist) == 1
+
     def neighbours(self, node, mode="all"):
         '''
         Return the neighbours of `node`.

--- a/nngt/core/gt_graph.py
+++ b/nngt/core/gt_graph.py
@@ -306,7 +306,6 @@ class _GtGraph(GraphInterface):
         see :class:`gt.Graph`'s constructor '''
         self._nattr = _GtNProperty(self)
         self._eattr = _GtEProperty(self)
-        self._directed = directed
         self._weighted = weighted
 
         g = copy_graph.graph if copy_graph is not None else None
@@ -592,7 +591,7 @@ class _GtGraph(GraphInterface):
     def degree_list(self, node_list=None, deg_type="total", use_weights=False):
         w = 1.
 
-        if not self._directed:
+        if not self._graph.is_directed():
             deg_type = "total"
             w = 0.5
 

--- a/nngt/core/gt_graph.py
+++ b/nngt/core/gt_graph.py
@@ -608,38 +608,6 @@ class _GtGraph(GraphInterface):
 
         return w*np.array(g.degree_property_map(deg_type).a[node_list])
 
-    def betweenness_list(self, btype="both", use_weights=False, as_prop=False,
-                         norm=True):
-        g = self._graph
-
-        if g.num_edges():
-            w_p = None
-
-            if "weight" in g.edge_properties and use_weights:
-                ws = self.get_weights()
-                self.set_edge_attribute(
-                    BWEIGHT, values=ws.max() - ws, value_type="double")
-                w_p = g.edge_properties[BWEIGHT]
-
-            tpl = nngt.analyze_graph["betweenness"](
-                self, weight=w_p, norm=norm)
-
-            if btype == "node":
-                return tpl[0] if as_prop else np.array(tpl[0].a)
-            elif btype == "edge":
-                return tpl[1] if as_prop else np.array(tpl[1].a)
-            else:
-                return ( np.array(tpl[0], tpl[1]) if as_prop
-                         else np.array(tpl[0].a), np.array(tpl[1].a) )
-        else:
-            if as_prop:
-                return (None, None) if btype == "both" else None
-            else:
-                if btype == "both":
-                    return np.array([]), np.array([])
-                else:
-                    return np.array([])
-
     def is_connected(self, mode="strong"):
         '''
         Return whether the graph is connected.

--- a/nngt/core/ig_graph.py
+++ b/nngt/core/ig_graph.py
@@ -255,8 +255,16 @@ class _IGraph(GraphInterface):
         g = copy_graph.graph if copy_graph is not None else None
 
         if g is None:
-            self._graph = nngt._config["graph"](n=nodes, directed=True)
+            self._graph = nngt._config["graph"](n=nodes, directed=directed)
         else:
+            # convert graph if necessary
+            if directed and not g.is_directed():
+                g = g.copy()
+                g.to_directed()
+            elif not directed and g.is_directed():
+                g = g.as_undirected(mode="collapse", combine_edges="sum")
+                g.simplify(combine_edges="sum")
+
             self._from_library_graph(g, copy=True)
 
     #-------------------------------------------------------------------------#
@@ -482,16 +490,6 @@ class _IGraph(GraphInterface):
             edge_list = np.array(edge_list)
             new_attr = attributes
 
-        if not self._directed:
-            recip_edges = edge_list[:,::-1]
-            # slow but works
-            unique = ~(recip_edges[..., np.newaxis]
-                      == edge_list[..., np.newaxis].T).all(1).any(1)
-            edge_list = np.concatenate((edge_list, recip_edges[unique]))
-
-            for key, val in new_attr.items():
-                new_attr[key] = np.concatenate((val, val[unique]))
-
         self._graph.add_edges(edge_list)
 
         # call parent function to set the attributes
@@ -517,12 +515,13 @@ class _IGraph(GraphInterface):
 
     def degree_list(self, node_list=None, deg_type="total", use_weights=False):
         g = self._graph
-    
+
         deg_type = 'all' if deg_type == 'total' else deg_type
 
-        if use_weights:
+        if use_weights is not False:
+            use_weights = 'weight' if use_weights is True else use_weights
             return np.array(g.strength(node_list, mode=deg_type,
-                            weights='weight'))
+                            weights=use_weights))
         else:
             return np.array(g.degree(node_list, mode=deg_type))
 

--- a/nngt/core/ig_graph.py
+++ b/nngt/core/ig_graph.py
@@ -525,42 +525,6 @@ class _IGraph(GraphInterface):
         else:
             return np.array(g.degree(node_list, mode=deg_type))
 
-    def betweenness_list(self, btype="both", use_weights=False, norm=True,
-                         **kwargs):
-        g = self._graph
-
-        n = g.vcount()
-        e = g.ecount()
-
-        ncoeff_norm = (n-1)*(n-2)
-        ecoeff_norm = (e-1)*(e-2)/2.
-
-        w, nbetw, ebetw = None, None, None
-
-        if use_weights:
-            if "bweight" in g.es:
-                w = g.es['bweight']
-            else:
-                w  = self.get_weights()
-                w  = np.max(w) - w
-                minw = np.min(w)
-                w += 1e-5*minw if minw > 0 else 1e-5
-
-        if btype in ("both", "node"):
-            nbetw = np.array(g.betweenness(weights=w))
-
-        if btype in ("both", "edge"):
-            ebetw = np.array(g.edge_betweenness(weights=w))
-
-        if btype == "node":
-            return nbetw/ncoeff_norm if norm else nbetw
-        elif btype == "edge":
-            return ebetw/ecoeff_norm if norm else ebetw
-        elif norm:
-            return nbetw/ncoeff_norm, ebetw/ecoeff_norm
-
-        return nbetw, ebetw
-
     def is_connected(self, mode="strong"):
         '''
         Return whether the graph is connected.

--- a/nngt/core/ig_graph.py
+++ b/nngt/core/ig_graph.py
@@ -561,6 +561,18 @@ class _IGraph(GraphInterface):
 
         return nbetw, ebetw
 
+    def is_connected(self, mode="strong"):
+        '''
+        Return whether the graph is connected.
+
+        Parameters
+        ----------
+        mode : str, optional (default: "strong")
+            Whether to test connectedness with directed ("strong") or
+            undirected ("weak") connections.
+        '''
+        return self._graph.is_connected(mode)
+
     def neighbours(self, node, mode="all"):
         '''
         Return the neighbours of `node`.

--- a/nngt/core/ig_graph.py
+++ b/nngt/core/ig_graph.py
@@ -249,8 +249,6 @@ class _IGraph(GraphInterface):
                  **kwargs):
         self._nattr = _IgNProperty(self)
         self._eattr = _IgEProperty(self)
-        self._weighted = weighted
-        self._directed = directed
 
         g = copy_graph.graph if copy_graph is not None else None
 

--- a/nngt/core/nngt_graph.py
+++ b/nngt/core/nngt_graph.py
@@ -335,6 +335,10 @@ class _NNGTGraph(GraphInterface):
         '''
         return np.array(list(self._edges.keys()), dtype=int)
 
+    def is_directed(self):
+        ''' Whether the graph is directed '''
+        return self._directed
+
     def new_node(self, n=1, neuron_type=1, attributes=None, value_types=None,
                  positions=None, groups=None):
         '''

--- a/nngt/core/nngt_graph.py
+++ b/nngt/core/nngt_graph.py
@@ -339,6 +339,11 @@ class _NNGTGraph(GraphInterface):
         ''' Whether the graph is directed '''
         return self._directed
 
+    def is_connected(self):
+        raise NotImplementedError("Not available with 'nngt' backend, please "
+                                  "install a graph library (networkx, igraph, "
+                                  "or graph-tool).")
+
     def new_node(self, n=1, neuron_type=1, attributes=None, value_types=None,
                  positions=None, groups=None):
         '''

--- a/nngt/core/nngt_graph.py
+++ b/nngt/core/nngt_graph.py
@@ -651,8 +651,8 @@ class _NNGTGraph(GraphInterface):
 
         degrees = np.zeros(num_nodes)
 
-        if "weight" in self._eattr and use_weights:
-            adj_mat = self.adjacency_matrix()
+        if use_weights:
+            adj_mat = self.adjacency_matrix(weights=use_weights)
 
             if not self._directed:
                 degrees += adj_mat.sum(axis=1).A1[node_list]

--- a/nngt/core/nngt_graph.py
+++ b/nngt/core/nngt_graph.py
@@ -671,12 +671,6 @@ class _NNGTGraph(GraphInterface):
 
         return degrees
 
-    def betweenness_list(self, btype="both", use_weights=False,
-                         as_prop=False, norm=True):
-        raise NotImplementedError(
-            "NNGT backup graph does not implement betweenness, install a "
-            "graph library to use it.")
-
     def neighbours(self, node, mode="all"):
         '''
         Return the neighbours of `node`.

--- a/nngt/core/nx_graph.py
+++ b/nngt/core/nx_graph.py
@@ -605,35 +605,6 @@ class _NxGraph(GraphInterface):
 
         return np.array([d[1] for d in di_deg])
 
-    def betweenness_list(self, btype="both", use_weights=False, **kwargs):
-        g  = self._graph
-        nx = nngt._config["library"]
-
-        di_nbetw, di_ebetw = None, None
-
-        wattr = None
-
-        if use_weights:
-            wattr = "bweight"
-
-            if "bweight" not in self._eattr:
-                w = self.get_weights()
-                w = w.max() - w if use_weights else None
-                self.new_edge_attribute("bweight", "double", values=w)
-
-        if btype in ("both", "node"):
-            di_nbetw = nx.betweenness_centrality(g, weight=wattr)
-        if btype in ("both", "edge"):
-            di_ebetw = nx.edge_betweenness_centrality(g, weight=wattr)
-
-        if btype == "node":
-            return np.array(tuple(di_nbetw.values()))
-        elif btype == "edge":
-            return np.array(tuple(di_ebetw.values()))
-
-        return (np.array(tuple(di_nbetw.values())),
-                np.array(tuple(di_ebetw.values())))
-
     def is_connected(self, mode="strong"):
         '''
         Return whether the graph is connected.

--- a/nngt/core/nx_graph.py
+++ b/nngt/core/nx_graph.py
@@ -285,9 +285,16 @@ class _NxGraph(GraphInterface):
         g = copy_graph.graph if copy_graph is not None else None
 
         if g is not None:
+            if not directed and g.is_directed():
+                g = g.to_undirected()
+            elif directed and not g.is_directed():
+                g = g.to_directed()
+
             self._from_library_graph(g, copy=True)
         else:
-            self._graph = nngt._config["graph"]()
+            nx = nngt._config["library"]
+
+            self._graph = nx.DiGraph() if directed else nx.Graph()
 
             if nodes:
                 self._graph.add_nodes_from(range(nodes))

--- a/nngt/core/nx_graph.py
+++ b/nngt/core/nx_graph.py
@@ -277,7 +277,6 @@ class _NxGraph(GraphInterface):
 
     def __init__(self, nodes=0, copy_graph=None, directed=True, weighted=False,
                  **kwargs):
-        self._weighted = weighted
         self._nattr = _NxNProperty(self)
         self._eattr = _NxEProperty(self)
 
@@ -474,7 +473,7 @@ class _NxGraph(GraphInterface):
                 if "_corr" in attr:
                     raise NotImplementedError("Correlated attributes are not "
                                               "available with networkx.")
-            if self._weighted and "weight" not in attributes:
+            if self.is_weighted() and "weight" not in attributes:
                 attributes["weight"] = 1.
 
             g.add_edge(source, target)

--- a/nngt/core/nx_graph.py
+++ b/nngt/core/nx_graph.py
@@ -484,13 +484,6 @@ class _NxGraph(GraphInterface):
             # call parent function to set the attributes
             self._attr_new_edges([(source, target)], attributes=attributes)
 
-            if not self._directed:
-                g.add_edge(target,source)
-                g[source][target]["eid"] = g.number_of_edges() - 1
-                for key, val in attributes.items():
-                    g[target][source][key] = val
-                self._attr_new_edges([(target, source)], attributes=attributes)
-
         return (source, target)
 
     def new_edges(self, edge_list, attributes=None, check_edges=True):
@@ -572,15 +565,6 @@ class _NxGraph(GraphInterface):
             arr_edges[:, :2] = edge_list
             arr_edges[:, 2]  = np.arange(initial_edges,
                 initial_edges + num_added)
-
-            if not self._directed:
-                recip_edges = edge_list[:, ::-1]
-                # slow but works
-                unique = ~(recip_edges[..., np.newaxis]
-                          == edge_list[..., np.newaxis].T).all(1).any(1)
-                edge_list = np.concatenate((edge_list, recip_edges[unique]))
-                for key, val in new_attr.items():
-                    new_attr[key] = np.concatenate((val, val[unique]))
 
             # create the edges with an eid attribute
             g.add_weighted_edges_from(arr_edges, weight="eid")

--- a/nngt/core/nx_graph.py
+++ b/nngt/core/nx_graph.py
@@ -634,6 +634,28 @@ class _NxGraph(GraphInterface):
         return (np.array(tuple(di_nbetw.values())),
                 np.array(tuple(di_ebetw.values())))
 
+    def is_connected(self, mode="strong"):
+        '''
+        Return whether the graph is connected.
+
+        Parameters
+        ----------
+        mode : str, optional (default: "strong")
+            Whether to test connectedness with directed ("strong") or
+            undirected ("weak") connections.
+        '''
+        g = self._graph
+
+        if g.is_directed() and mode == "weak":
+            g = g.to_undirected(as_view=True)
+
+        try:
+            import networkx as nx
+            nx.diameter(g)
+            return True
+        except nx.exception.NetworkXError:
+            return False
+
     def neighbours(self, node, mode="all"):
         '''
         Return the neighbours of `node`.

--- a/nngt/core/nx_graph.py
+++ b/nngt/core/nx_graph.py
@@ -277,7 +277,6 @@ class _NxGraph(GraphInterface):
 
     def __init__(self, nodes=0, copy_graph=None, directed=True, weighted=False,
                  **kwargs):
-        self._directed = directed
         self._weighted = weighted
         self._nattr = _NxNProperty(self)
         self._eattr = _NxEProperty(self)

--- a/nngt/database/db_main.py
+++ b/nngt/database/db_main.py
@@ -127,10 +127,10 @@ class NNGTdb:
             New NeuralNetwork entry.
         '''
         if network is not None:
-            weighted = network._weighted
+            weighted = network.is_weighted()
             net_prop = {
                 'network_type': network.type,
-                'directed': network._directed,
+                'directed': network.is_directed(),
                 'nodes': network.node_nb(),
                 'edges': network.edge_nb(),
                 'weighted': weighted,

--- a/nngt/lib/graph_backends.py
+++ b/nngt/lib/graph_backends.py
@@ -82,9 +82,11 @@ def use_backend(backend, reloading=True, silent=False):
     old_config = nngt.get_config(detailed=True)
     for k in ("graph", "backend", "library"):
         del old_config[k]
+
     # try to switch graph library
     success = False
     error = None
+
     if backend == "graph-tool":
         try:
             success = _set_graph_tool()
@@ -107,24 +109,24 @@ def use_backend(backend, reloading=True, silent=False):
             error = e
     else:
         raise ValueError("Invalid graph library requested.")
+
     if reloading:
-        reload(sys.modules["nngt"].core.graph_interface)
-        reload(sys.modules["nngt"].core.nngt_graph)
-        reload(sys.modules["nngt"].core.gt_graph)
-        reload(sys.modules["nngt"].core.ig_graph)
-        reload(sys.modules["nngt"].core.nx_graph)
-        reload(sys.modules["nngt"].core)
-        reload(sys.modules["nngt"].generation)
+        reload(sys.modules["nngt"].analysis.graph_analysis)
+        reload(sys.modules["nngt"].analysis)  # must come after  graph_analysis
         reload(sys.modules["nngt"].generation.graph_connectivity)
+        reload(sys.modules["nngt"].generation)
+
         if nngt._config['with_plot']:
             reload(sys.modules["nngt"].plot)
+
         if nngt._config['with_nest']:
             reload(sys.modules["nngt"].simulation)
+
         reload(sys.modules["nngt"].lib)
+        reload(sys.modules["nngt"].core)  # reload first for Graph inheritance
         reload(sys.modules["nngt"].core.graph)
         reload(sys.modules["nngt"].core.spatial_graph)
         reload(sys.modules["nngt"].core.networks)
-        reload(sys.modules["nngt"].analysis)
 
         from nngt.core.graph import Graph
         from nngt.core.spatial_graph import SpatialGraph
@@ -134,8 +136,10 @@ def use_backend(backend, reloading=True, silent=False):
         sys.modules["nngt"].SpatialGraph = SpatialGraph
         sys.modules["nngt"].Network = Network
         sys.modules["nngt"].SpatialNetwork = SpatialNetwork
+
     # restore old config
     nngt.set_config(old_config, silent=True)
+
     # log
     if success:
         if silent:

--- a/nngt/lib/graph_backends.py
+++ b/nngt/lib/graph_backends.py
@@ -194,9 +194,9 @@ def _set_igraph():
     nngt._config["graph"]   = GraphLib
 
     # store the functions
-    from ..analysis import gt_functions
+    from ..analysis import ig_functions
 
-    _store_functions(nngt.analyze_graph, gt_functions)
+    _store_functions(nngt.analyze_graph, ig_functions)
 
     return True
 
@@ -206,77 +206,16 @@ def _set_networkx():
     if glib.__version__ < '2.4':
         raise ImportError("`networkx {} is ".format(glib.__version__) +\
                           "installed while version >= 2.4 is required.")
+
     from networkx import DiGraph as GraphLib
     nngt._config["backend"] = "networkx"
     nngt._config["library"] = glib
     nngt._config["graph"]   = GraphLib
-    # analysis functions
-    from networkx.algorithms import ( diameter,
-        strongly_connected_components, weakly_connected_components,
-        degree_assortativity_coefficient )
 
-    def diam(g):
-        return diameter(g.graph)
+    # store the functions
+    from ..analysis import nx_functions
 
-    def scc(g):
-        return strongly_connected_components(g.graph)
-
-    def wcc(g):
-        return weakly_connected_components(g.graph)
-
-    def deg_assort_coef(g):
-        return degree_assortativity_coefficient(g.graph)
-
-    def clustering(g):
-        return glib.transitivity(g.graph)
-
-    def _closeness(g, nodes, weights):
-        if weights is True and g.is_weighted():
-            weights = g.edge_properties[weight]
-        else:
-            weights=None
-        if nodes is None:
-            return glib.closeness_centrality(g.graph, distance=weights)
-        else:
-            c = [glib.closeness_centrality(g.graph, u=n, distance=weights)
-                 for n in nodes]
-            return c
-
-    def overall_reciprocity(g):
-        num_edges = g.graph.number_of_edges()
-        num_recip = (num_edges - g.graph.to_undirected().number_of_edges()) * 2
-        if n_all_edge == 0:
-            raise ArgumentError("Not defined for empty graphs")
-        else:
-            return num_recip/float(num_edges)
-
-    nx_version = glib.__version__
-
-    from networkx.algorithms import overall_reciprocity
-
-    def overall_recip(g):
-        return overall_reciprocity(g.graph)
-
-    def local_clustering(g, nodes=None):
-        return np.array(glib.clustering(g.graph, nodes).values())
-
-    # defining the adjacency function
-    from networkx import to_scipy_sparse_matrix
-    def adj_mat(g, weight=None):
-        return to_scipy_sparse_matrix(g.graph, weight=weight)
-    def get_edges(g):
-        return g.graph.edges(data=False)
-    # store functions
-    nngt.analyze_graph["assortativity"] = deg_assort_coef
-    nngt.analyze_graph["diameter"] = diam
-    nngt.analyze_graph["closeness"] = _closeness
-    nngt.analyze_graph["clustering"] = clustering
-    nngt.analyze_graph["local_clustering"] = local_clustering
-    nngt.analyze_graph["reciprocity"] = overall_recip
-    nngt.analyze_graph["scc"] = scc
-    nngt.analyze_graph["wcc"] = wcc
-    nngt.analyze_graph["adjacency"] = adj_mat
-    nngt.analyze_graph["get_edges"] = get_edges
+    _store_functions(nngt.analyze_graph, nx_functions)
 
     return True
 

--- a/nngt/lib/graph_backends.py
+++ b/nngt/lib/graph_backends.py
@@ -249,6 +249,7 @@ def _set_nngt():
 
     # store functions
     nngt.analyze_graph["assortativity"] = _notimplemented
+    nngt.analyze_graph["betweenness"] = _notimplemented
     nngt.analyze_graph["diameter"] = _notimplemented
     nngt.analyze_graph["closeness"] = _notimplemented
     nngt.analyze_graph["clustering"] = _notimplemented
@@ -264,6 +265,7 @@ def _set_nngt():
 def _store_functions(analysis_dict, module):
     ''' Store functions from module '''
     analysis_dict["assortativity"] = module.assortativity
+    analysis_dict["betweenness"] = module.betweenness
     analysis_dict["closeness"] = module.closeness
     analysis_dict["global_clustering"] = module.global_clustering
     analysis_dict["local_clustering"] = module.undirected_local_clustering

--- a/nngt/lib/graph_backends.py
+++ b/nngt/lib/graph_backends.py
@@ -325,7 +325,7 @@ def _set_nngt():
 def _store_functions(analysis_dict, module):
     ''' Store functions from module '''
     analysis_dict["assortativity"] = module.assortativity
-    analysis_dict["betweenness"] = module.betwenness
+    analysis_dict["betweenness"] = module.betweenness
     analysis_dict["closeness"] = module.closeness
     analysis_dict["clustering"] = module.global_clustering
     analysis_dict["local_clustering"] = module.local_clustering

--- a/nngt/lib/graph_backends.py
+++ b/nngt/lib/graph_backends.py
@@ -325,7 +325,6 @@ def _set_nngt():
 def _store_functions(analysis_dict, module):
     ''' Store functions from module '''
     analysis_dict["assortativity"] = module.assortativity
-    analysis_dict["betweenness"] = module.betweenness
     analysis_dict["closeness"] = module.closeness
     analysis_dict["clustering"] = module.global_clustering
     analysis_dict["local_clustering"] = module.local_clustering

--- a/nngt/lib/graph_backends.py
+++ b/nngt/lib/graph_backends.py
@@ -265,8 +265,8 @@ def _store_functions(analysis_dict, module):
     ''' Store functions from module '''
     analysis_dict["assortativity"] = module.assortativity
     analysis_dict["closeness"] = module.closeness
-    analysis_dict["clustering"] = module.global_clustering
-    analysis_dict["local_clustering"] = module.local_clustering
+    analysis_dict["global_clustering"] = module.global_clustering
+    analysis_dict["local_clustering"] = module.undirected_local_clustering
     analysis_dict["scc"] = module.connected_components
     analysis_dict["wcc"] = module.connected_components
     analysis_dict["diameter"] = module.diameter

--- a/nngt/lib/graph_backends.py
+++ b/nngt/lib/graph_backends.py
@@ -255,8 +255,7 @@ def _set_nngt():
     nngt.analyze_graph["clustering"] = _notimplemented
     nngt.analyze_graph["local_clustering"] = _notimplemented
     nngt.analyze_graph["reciprocity"] = _notimplemented
-    nngt.analyze_graph["scc"] = _notimplemented
-    nngt.analyze_graph["wcc"] = _notimplemented
+    nngt.analyze_graph["connected_components"] = _notimplemented
     nngt.analyze_graph["adjacency"] = adj_mat
     nngt.analyze_graph["get_edges"] = get_edges
     return True
@@ -267,11 +266,10 @@ def _store_functions(analysis_dict, module):
     analysis_dict["assortativity"] = module.assortativity
     analysis_dict["betweenness"] = module.betweenness
     analysis_dict["closeness"] = module.closeness
+    analysis_dict["connected_components"] = module.connected_components
+    analysis_dict["diameter"] = module.diameter
     analysis_dict["global_clustering"] = module.global_clustering
     analysis_dict["local_clustering"] = module.undirected_local_clustering
-    analysis_dict["scc"] = module.connected_components
-    analysis_dict["wcc"] = module.connected_components
-    analysis_dict["diameter"] = module.diameter
     analysis_dict["reciprocity"] = module.reciprocity
     analysis_dict["adjacency"] = module.adj_mat
     analysis_dict["get_edges"] = module.get_edges

--- a/nngt/lib/graph_helpers.py
+++ b/nngt/lib/graph_helpers.py
@@ -48,7 +48,7 @@ def _get_edge_attr(graph, elist, attribute, prop=None, last_edges=False):
     # check the weights
     if "weight" == attribute:
         weights = np.ones(len(elist))
-        if graph._weighted:
+        if graph.is_weighted():
             if prop is None:
                 prop = graph._w
             else:

--- a/nngt/lib/io_tools.py
+++ b/nngt/lib/io_tools.py
@@ -95,7 +95,6 @@ def load_from_file(filename, fmt="auto", separator=" ", secondary=";",
         attributes=attributes, notifier=notifier, ignore=ignore)
 
 
-@graph_tool_check('2.22')
 def _load_from_file(filename, fmt="auto", separator=" ", secondary=";",
                    attributes=None, notifier="@", ignore="#"):
     '''
@@ -165,8 +164,10 @@ def _load_from_file(filename, fmt="auto", separator=" ", secondary=";",
     lst_lines = lst_lines[::-1][:-len(di_notif)]
     while not lst_lines[-1] or lst_lines[-1].startswith(ignore):
         lst_lines.pop()
+
     # get nodes attributes
     di_nattributes  = _get_node_attr(di_notif, separator)
+
     # make edges and attributes
     edges           = []
     eattributes     = (di_notif["edge_attributes"] if attributes is None
@@ -222,6 +223,7 @@ def _load_from_file(filename, fmt="auto", separator=" ", secondary=";",
             _log_message(logger, "WARNING",
                          'A Shape object was present in the file but could '
                          'not be loaded because Shapely is not installed.')
+
     # check whether a population is present
     if 'population' in di_notif:
         str_enc = di_notif['population'].replace('~', '\n').encode()
@@ -230,6 +232,7 @@ def _load_from_file(filename, fmt="auto", separator=" ", secondary=";",
             pop = pickle.loads(str_dec)
         except UnicodeError:
             pop = pickle.loads(str_dec, encoding="latin1")
+
     if 'x' in di_notif:
         x = np.fromstring(di_notif['x'], sep=separator)
         y = np.fromstring(di_notif['y'], sep=separator)

--- a/nngt/lib/io_tools.py
+++ b/nngt/lib/io_tools.py
@@ -398,7 +398,7 @@ def _as_string(graph, fmt="neighbour", separator=" ", secondary=";",
         attributes = [a for a in graph.edges_attributes if a != "bweight"]
     nattributes = [a for a in graph.nodes_attributes]
     additional_notif = {
-        "directed": graph._directed,
+        "directed": graph.is_directed(),
         "node_attributes": nattributes,
         "node_attr_types": [
             graph.get_attribute_type(nattr, "node") for nattr in nattributes

--- a/nngt/plot/plt_networks.py
+++ b/nngt/plot/plt_networks.py
@@ -31,7 +31,6 @@ from mpl_toolkits.axes_grid1 import make_axes_locatable
 
 import nngt
 from nngt.lib import POS, nonstring_container
-from nngt.analysis import num_wcc
 from .custom_plt import palette_continuous, palette_discrete, format_exponent
 
 
@@ -585,7 +584,7 @@ def _node_size(network, restrict_nodes, nsize):
         else:
             betw = network.betweenness_list("node").astype(float)[restrict_nodes]
 
-        if num_wcc(network) == 1:
+        if network.is_connected("weak") == 1:
             size *= betw
             if size.max() > 15*size.min():
                 min_size = size[size!=0].min()

--- a/testing/library_compatibility.py
+++ b/testing/library_compatibility.py
@@ -1,0 +1,46 @@
+#!/usr/bin/env python
+#-*- coding:utf-8 -*-
+
+# library_compatibility.py
+
+# This file is part of the NNGT module
+# Distributed as a free software, in the hope that it will be useful, under the
+# terms of the GNU General Public License.
+
+""" Test the graph analysis function for all backends """
+
+import numpy as np
+
+import nngt
+import nngt.analysis as na
+
+
+def test_clustering():
+    ''' Check the clustering coefficient results '''
+    backends = ["networkx", "igraph", "graph-tool"]
+    results  = {}
+
+    # create a pre-defined graph
+    num_nodes = 5
+    # ~ edge_list = [(0, 3), (1, 0), (1, 2), (2, 4), (4, 1), (4, 3)]
+    edge_list = [(0, 3), (3, 0), (1, 0), (0, 1), (1, 2), (2, 1), (2, 4), (4, 2), (4, 1), (1, 4), (4, 3), (3, 4)]
+
+    for bckd in backends:
+        nngt.set_config("backend", bckd)
+
+        g = nngt.Graph(nodes=num_nodes)
+        g.new_edges(edge_list)
+
+        results[bckd] = nngt.analyze_graph["local_clustering"](g)
+
+    print(results)
+
+    nngt.plot.draw_network(g, show=True)
+
+    assert np.all(np.isclose(results[backends[0]], results[backends[1]]) &
+                  np.isclose(results[backends[0]], results[backends[2]])), \
+        "Differing clustering coefficients: {}".format(results)
+
+
+if __name__ == "__main__":
+    test_clustering()

--- a/testing/library_compatibility.py
+++ b/testing/library_compatibility.py
@@ -15,11 +15,11 @@ import nngt
 import nngt.analysis as na
 
 
-def test_clustering():
-    ''' Check the clustering coefficient results '''
-    backends = ["networkx", "igraph", "graph-tool"]
-    results  = {}
+backends = ["networkx", "igraph", "graph-tool"]
 
+
+def test_clustering():
+    ''' Check the clustering coefficient results for all backends '''
     # create a pre-defined graph
     num_nodes = 5
     edge_list = [
@@ -43,5 +43,81 @@ def test_clustering():
             nngt.analyze_graph["global_clustering"](g), glob_clst)
 
 
+def test_assortativity():
+    ''' Check assortativity result for all backends '''
+    # DIRECTED
+    num_nodes = 5
+    edge_list = [(0, 3), (1, 0), (1, 2), (2, 4), (4, 1), (4, 3), (4, 2)]
+    weights   = [0.53, 0.45, 0.8, 0.125, 0.66, 0.31, 0.78]
+
+    # expected results
+    assort_unweighted = -0.47140452079103046
+    assort_weighted   = -0.5457956719785911
+
+    for bckd in backends:
+        nngt.set_config("backend", bckd)
+
+        g = nngt.Graph(nodes=num_nodes)
+        g.new_edges(edge_list, attributes={"weight": weights})
+
+        assert np.isclose(
+            nngt.analyze_graph["assortativity"](g, "in"), assort_unweighted)
+
+        # not check weighted version for networkx for now
+        if bckd != "networkx":
+            assert np.isclose(
+                nngt.analyze_graph["assortativity"](g, "in", weights=True),
+                assort_weighted)
+
+    # UNDIRECTED
+    edge_list = [(0, 3), (1, 0), (1, 2), (2, 4), (4, 1), (4, 3)]
+
+    # expected results
+    assort_unweighted = -0.33333333333333215
+    assort_weighted   = -0.27351320394915296
+
+    for bckd in backends:
+        nngt.set_config("backend", bckd)
+
+        g = nngt.Graph(nodes=num_nodes, directed=False)
+        g.new_edges(edge_list, attributes={"weight": weights})
+
+        assert np.isclose(
+            nngt.analyze_graph["assortativity"](g, "in"), assort_unweighted)
+
+        # not check weighted version for networkx for now
+        if bckd != "networkx":
+            assert np.isclose(
+                nngt.analyze_graph["assortativity"](g, "in", weights=True),
+                assort_weighted)
+
+
+def test_reciprocity():
+    ''' Check reciprocity result for all backends '''
+    num_nodes  = 5
+    edge_list1 = [(0, 3), (1, 0), (1, 2), (2, 4), (4, 1), (4, 3), (4, 2)]
+    edge_list2 = [(0, 3), (1, 0), (1, 2), (2, 4), (4, 1), (4, 3)]
+
+    recip = 2/7
+
+    for bckd in backends:
+        nngt.set_config("backend", bckd)
+
+        # directed
+        g = nngt.Graph(nodes=num_nodes, directed=True)
+        g.new_edges(edge_list1)
+
+        assert np.isclose(
+            nngt.analyze_graph["reciprocity"](g), recip)
+
+        # undirected
+        g = nngt.Graph(nodes=num_nodes, directed=False)
+        g.new_edges(edge_list2)
+
+        assert nngt.analyze_graph["reciprocity"](g) == 1.
+
+
 if __name__ == "__main__":
     test_clustering()
+    test_assortativity()
+    test_reciprocity()

--- a/testing/library_compatibility.py
+++ b/testing/library_compatibility.py
@@ -22,8 +22,13 @@ def test_clustering():
 
     # create a pre-defined graph
     num_nodes = 5
-    # ~ edge_list = [(0, 3), (1, 0), (1, 2), (2, 4), (4, 1), (4, 3)]
-    edge_list = [(0, 3), (3, 0), (1, 0), (0, 1), (1, 2), (2, 1), (2, 4), (4, 2), (4, 1), (1, 4), (4, 3), (3, 4)]
+    edge_list = [
+        (0, 3), (1, 0), (1, 2), (2, 4), (4, 1), (4, 3), (4, 2), (4, 0)
+    ]
+
+    # expected results
+    loc_clst  = [2/3., 2/3., 1., 1., 0.5]
+    glob_clst = 0.6428571428571429
 
     for bckd in backends:
         nngt.set_config("backend", bckd)
@@ -31,15 +36,11 @@ def test_clustering():
         g = nngt.Graph(nodes=num_nodes)
         g.new_edges(edge_list)
 
-        results[bckd] = nngt.analyze_graph["local_clustering"](g)
+        assert np.all(np.isclose(
+            nngt.analyze_graph["local_clustering"](g), loc_clst))
 
-    print(results)
-
-    nngt.plot.draw_network(g, show=True)
-
-    assert np.all(np.isclose(results[backends[0]], results[backends[1]]) &
-                  np.isclose(results[backends[0]], results[backends[2]])), \
-        "Differing clustering coefficients: {}".format(results)
+        assert np.isclose(
+            nngt.analyze_graph["global_clustering"](g), glob_clst)
 
 
 if __name__ == "__main__":

--- a/testing/library_compatibility.py
+++ b/testing/library_compatibility.py
@@ -359,8 +359,39 @@ def test_components():
 
 def test_diameter():
     ''' Check connected components for all backends '''
-    pass
-    
+    # unconnected
+    num_nodes = 8
+    edge_list = [(0, 1), (0, 2), (1, 2)]
+
+    for i in range(3, num_nodes - 1):
+        edge_list.append((i, i+1))
+
+    edge_list.append((7, 3))
+
+    for bckd in backends:
+        nngt.set_config("backend", bckd)
+
+        g = nngt.Graph(nodes=num_nodes, directed=True)
+        g.new_edges(edge_list)
+
+        d = nngt.analyze_graph["diameter"](g)
+
+        assert np.isinf(d)
+
+    # connected
+    num_nodes = 5
+    edge_list = [(0, 1), (0, 3), (1, 3), (2, 0), (3, 2), (3, 4), (4, 2)]
+
+    for bckd in backends:
+        nngt.set_config("backend", bckd)
+
+        g = nngt.Graph(nodes=num_nodes, directed=True)
+        g.new_edges(edge_list)
+
+        d = nngt.analyze_graph["diameter"](g)
+
+        assert d == 3
+
 
 if __name__ == "__main__":
     # ~ test_clustering()

--- a/testing/library_compatibility.py
+++ b/testing/library_compatibility.py
@@ -368,36 +368,43 @@ def test_diameter():
 
     edge_list.append((7, 3))
 
+    weights = [0.58, 0.59, 0.88, 0.8, 0.61, 0.66, 0.62, 0.28]
+
     for bckd in backends:
         nngt.set_config("backend", bckd)
 
         g = nngt.Graph(nodes=num_nodes, directed=True)
-        g.new_edges(edge_list)
+        g.new_edges(edge_list, attributes={"weight": weights})
 
-        d = nngt.analyze_graph["diameter"](g)
+        assert np.isinf(nngt.analyze_graph["diameter"](g, weights=None))
 
-        assert np.isinf(d)
+        assert np.isinf(nngt.analyze_graph["diameter"](g, weights=True))
 
     # connected
     num_nodes = 5
     edge_list = [(0, 1), (0, 3), (1, 3), (2, 0), (3, 2), (3, 4), (4, 2)]
 
+    weights = [0.58, 0.59, 0.88, 0.8, 0.61, 0.66, 0.28]
+
     for bckd in backends:
         nngt.set_config("backend", bckd)
 
         g = nngt.Graph(nodes=num_nodes, directed=True)
-        g.new_edges(edge_list)
+        g.new_edges(edge_list, attributes={"weight": weights})
 
         d = nngt.analyze_graph["diameter"](g)
 
-        assert d == 3
+        assert nngt.analyze_graph["diameter"](g, weights=None) == 3
+
+        assert np.isclose(
+            nngt.analyze_graph["diameter"](g, weights="weight"), 2.29)
 
 
 if __name__ == "__main__":
-    # ~ test_clustering()
-    # ~ test_assortativity()
-    # ~ test_reciprocity()
-    # ~ test_closeness()
-    # ~ test_betweenness()
-    # ~ test_components()
+    test_clustering()
+    test_assortativity()
+    test_reciprocity()
+    test_closeness()
+    test_betweenness()
+    test_components()
     test_diameter()

--- a/testing/library_compatibility.py
+++ b/testing/library_compatibility.py
@@ -400,6 +400,26 @@ def test_diameter():
             nngt.analyze_graph["diameter"](g, weights="weight"), 2.29)
 
 
+def test_subgraph_centrality():
+    ''' Check subgraph centrality with networkx implementation '''
+    num_nodes  = 5
+    edge_list  = [(0, 1), (0, 2), (0, 3), (1, 3), (2, 3), (2, 4), (3, 4)]
+
+    nngt.set_config("backend", "networkx")
+
+    g = nngt.Graph(num_nodes, directed=False)
+    g.new_edges(edge_list)
+
+    import networkx as nx
+
+    sc_nx = nx.subgraph_centrality(g.graph)
+
+    sc_nngt = nngt.analysis.subgraph_centrality(g, weights=False,
+                                                normalize=False)
+
+    assert np.all(np.isclose(sc_nx, sc_nngt))
+
+
 if __name__ == "__main__":
     test_clustering()
     test_assortativity()
@@ -408,3 +428,4 @@ if __name__ == "__main__":
     test_betweenness()
     test_components()
     test_diameter()
+    test_subgraph_centrality()

--- a/testing/library_compatibility.py
+++ b/testing/library_compatibility.py
@@ -413,6 +413,7 @@ def test_subgraph_centrality():
     import networkx as nx
 
     sc_nx = nx.subgraph_centrality(g.graph)
+    sc_nx = [sc_nx[i] for i in range(num_nodes)]
 
     sc_nngt = nngt.analysis.subgraph_centrality(g, weights=False,
                                                 normalize=False)

--- a/testing/library_compatibility.py
+++ b/testing/library_compatibility.py
@@ -335,7 +335,19 @@ def test_components():
         cc, hist = \
             nngt.analyze_graph["connected_components"](g, ctype="wcc")
 
-        print(bckd, "wcc", cc, hist)
+        # nodes are assigned to the correct components
+        assert np.all(cc[:3] == cc[0])  # 3 first together
+        assert np.all(cc[3:] == cc[3])  # 5 last together
+        # hence counts should be 3 and 5
+        assert hist[cc[0]] == 3
+        assert hist[cc[5]] == 5
+
+        # undirected
+        g = nngt.Graph(nodes=num_nodes, directed=False)
+        g.new_edges(edge_list)
+
+        cc, hist = \
+            nngt.analyze_graph["connected_components"](g)
 
         # nodes are assigned to the correct components
         assert np.all(cc[:3] == cc[0])  # 3 first together
@@ -343,6 +355,11 @@ def test_components():
         # hence counts should be 3 and 5
         assert hist[cc[0]] == 3
         assert hist[cc[5]] == 5
+
+
+def test_diameter():
+    ''' Check connected components for all backends '''
+    pass
     
 
 if __name__ == "__main__":
@@ -351,4 +368,5 @@ if __name__ == "__main__":
     # ~ test_reciprocity()
     # ~ test_closeness()
     # ~ test_betweenness()
-    test_components()
+    # ~ test_components()
+    test_diameter()

--- a/testing/test_basics.py
+++ b/testing/test_basics.py
@@ -14,7 +14,7 @@ import numpy as np
 
 import nngt
 
-    
+
 tolerance = 1e-6
 
 
@@ -154,11 +154,113 @@ def test_graph_copy():
     assert g.shape is not copy.shape
 
 
+def test_adjacency():
+    ''' Check adjacency matrix '''
+    num_nodes = 5
+    edge_list = [(0, 1), (0, 3), (1, 3), (2, 0), (3, 2), (3, 4), (4, 2)]
+    weights   = [0.54881, 0.71518, 0.60276, 0.54488, 0.42365, 0.64589, 0.43758]
+    etypes    = [-1, 1, 1, -1, -1, 1, 1]
+
+    g = nngt.Graph(num_nodes)
+    g.new_edges(edge_list, attributes={"weight": weights})
+    g.new_edge_attribute("type", "int", values=etypes)
+
+    adj_mat = np.array([
+        [0, 1, 0, 1, 0],
+        [0, 0, 0, 1, 0],
+        [1, 0, 0, 0, 0],
+        [0, 0, 1, 0, 1],
+        [0, 0, 1, 0, 0]
+    ])
+
+    assert np.all(np.isclose(g.adjacency_matrix(weights=False).todense(),
+                             adj_mat))
+
+    w_mat = np.array([
+        [0,       0.54881, 0,       0.71518, 0      ],
+        [0,       0,       0,       0.60276, 0      ],
+        [0.54488, 0,       0,       0,       0      ],
+        [0,       0,       0.42365, 0,       0.64589],
+        [0,       0,       0.43758, 0,       0]
+    ])
+
+    assert np.all(np.isclose(g.adjacency_matrix(weights=True).todense(),
+                             w_mat))
+
+    # for typed edges
+    tpd_mat = np.array([
+        [ 0, -1,  0, 1, 0],
+        [ 0,  0,  0, 1, 0],
+        [-1,  0,  0, 0, 0],
+        [ 0,  0, -1, 0, 1],
+        [ 0,  0,  1, 0, 0]
+    ])
+
+    assert np.all(np.isclose(g.adjacency_matrix(types=True).todense(),
+                             tpd_mat))
+
+    wt_mat = np.array([
+        [ 0,       -0.54881,  0,       0.71518, 0      ],
+        [ 0,        0,        0,       0.60276, 0      ],
+        [-0.54488,  0,        0,       0,       0      ],
+        [ 0,        0,       -0.42365, 0,       0.64589],
+        [ 0,        0,        0.43758, 0,       0]
+    ])
+
+    assert np.all(np.isclose(
+        g.adjacency_matrix(types=True, weights=True).todense(), wt_mat))
+
+    # for Network and node attribute type
+    num_nodes = 5
+    edge_list = [(0, 1), (0, 3), (1, 3), (2, 0), (3, 2), (3, 4), (4, 2)]
+    weights   = [0.54881, 0.71518, 0.60276, 0.54488, 0.42365, 0.64589, 0.43758]
+
+    inh = nngt.NeuralGroup([0, 2, 4], neuron_type=-1, name="inh")
+    exc = nngt.NeuralGroup([1, 3], neuron_type=1, name="exc")
+    pop = nngt.NeuralPop.from_groups((inh, exc), with_models=False)
+
+    net = nngt.Network(population=pop)
+    net.new_edges(edge_list, attributes={"weight": weights})
+
+    g = nngt.Graph(num_nodes)
+    g.new_node_attribute("type", "int", values=[-1, 1, -1, 1, -1])
+    g.new_edges(edge_list, attributes={"weight": weights})
+
+    tpd_mat = np.array([
+        [ 0, -1,  0, -1, 0],
+        [ 0,  0,  0,  1, 0],
+        [-1,  0,  0,  0, 0],
+        [ 0,  0,  1,  0, 1],
+        [ 0,  0, -1,  0, 0]
+    ])
+
+    assert np.all(np.isclose(net.adjacency_matrix(types=True).todense(),
+                             tpd_mat))
+
+    assert np.all(np.isclose(g.adjacency_matrix(types=True).todense(),
+                             tpd_mat))
+
+    wt_mat = np.array([
+        [ 0,       -0.54881,  0,       -0.71518, 0      ],
+        [ 0,        0,        0,        0.60276, 0      ],
+        [-0.54488,  0,        0,        0,       0      ],
+        [ 0,        0,        0.42365,  0,       0.64589],
+        [ 0,        0,       -0.43758,  0,       0]
+    ])
+
+    assert np.all(np.isclose(
+        net.adjacency_matrix(types=True, weights=True).todense(), wt_mat))
+
+    assert np.all(np.isclose(
+        g.adjacency_matrix(types=True, weights=True).todense(), wt_mat))
+
+
 # ---------- #
 # Test suite #
 # ---------- #
 
 if __name__ == "__main__":
+    test_adjacency()
     test_config()
     test_new_node_attr()
     test_graph_copy()

--- a/testing/test_graphclasses.py
+++ b/testing/test_graphclasses.py
@@ -57,7 +57,7 @@ class TestGraphClasses(TestBasis):
         graph.adjacency_matrix() is the same as the initial matrix.
         '''
         ref_result = ssp.csr_matrix(self.matrices[graph.name])
-        computed_result = graph.adjacency_matrix()
+        computed_result = graph.adjacency_matrix(weights=True)
         self.assertTrue(
             (ref_result != computed_result).nnz == 0,
             "AdjMat test failed for graph {}:\nref = {} vs exp {}\

--- a/testing/test_weights.py
+++ b/testing/test_weights.py
@@ -80,5 +80,6 @@ def test_weighted_degrees():
 
 
 if __name__ == "__main__":
+    nngt.set_config("backend", "nngt")
     test_set_weights()
     test_weighted_degrees()


### PR DESCRIPTION
This PR provides full compatibility between networkx, igraph, and graph-tool backends for a series of analysis functions.

* refactoring of analysis functions
* test and comparison of analysis functions
* complete support for undirected graphs
* added ``is_connected`` method
* removed ``num_wcc`` and ``num_scc`` in favor of``connected_components``
* ``adjacency_matrix`` is now binary by default