### PR TITLE
Fix neighbours and link to undirected clustering

### DIFF
--- a/doc/user/graph-analysis.rst
+++ b/doc/user/graph-analysis.rst
@@ -55,7 +55,7 @@ the function will raise an error if one tries to use it on such graphs.
 +----------------------------------------------------+-----------------------+---------------------+---------------------+--------------------+
 | :func:`~nngt.analysis.global_clustering`           |    gt, nx, ig         |   x                 |   x                 |   x                |
 +----------------------------------------------------+-----------------------+---------------------+---------------------+--------------------+
-| :func:`~nngt.analysis.local_clustering`            |    gt, nx, ig         |   x                 |   x                 |   x                |
+| :func:`~nngt.analysis.local_clustering` [4]_       |    gt, nx, ig         |   x                 |   x                 |   x                |
 +----------------------------------------------------+-----------------------+---------------------+---------------------+--------------------+
 | :func:`~nngt.analysis.reciprocity`                 |    gt, nx, ig         |   gt, nx, ig        |   gt, nx, ig        |   gt, nx, ig       |
 +----------------------------------------------------+-----------------------+---------------------+---------------------+--------------------+
@@ -63,7 +63,7 @@ the function will raise an error if one tries to use it on such graphs.
 +----------------------------------------------------+-----------------------+---------------------+---------------------+--------------------+
 | :func:`~nngt.analysis.subgraph_centrality`         |    nngt               |   nngt              |   nngt              |   nngt             |
 +----------------------------------------------------+-----------------------+---------------------+---------------------+--------------------+
-| :func:`~nngt.analysis.transitivity` [4]_           |    gt, nx, ig         |   x                 |   x                 |   x                |
+| :func:`~nngt.analysis.transitivity` [5]_           |    gt, nx, ig         |   x                 |   x                 |   x                |
 +----------------------------------------------------+-----------------------+---------------------+---------------------+--------------------+
 
 
@@ -76,7 +76,10 @@ the function will raise an error if one tries to use it on such graphs.
        harmonic closeness.
 .. [3] the implementation of the diameter for graph-tool is approximmate so
        results may occasionaly be inexact with this backend.
-.. [4] identical to ``global_clustering``.
+.. [4] for directed and weighted networks, definitions and implementations
+       differ between graph libraries, generic implementation in NNGT will
+       come soon.
+.. [5] identical to ``global_clustering``.
 
 ----
 

--- a/nngt/analysis/graph_analysis.py
+++ b/nngt/analysis/graph_analysis.py
@@ -417,7 +417,7 @@ def local_clustering(g, weights=None, nodes=None):
     lc : :class:`numpy.ndarray`
         The list of clustering coefficients, on per node.
     '''
-    if not graph.is_directed():
+    if not g.is_directed():
         return undirected_local_clustering(g, weights=weights, nodes=nodes)
 
     raise NotImplementedError("`local_clustering` is not yet implemented for "

--- a/nngt/core/graph.py
+++ b/nngt/core/graph.py
@@ -1065,6 +1065,27 @@ class Graph(nngt.core.GraphObject):
         else:
             return self._eattr[edges]["delay"]
 
+    def neighbours(self, node, mode="all"):
+        '''
+        Return the neighbours of `node`.
+
+        Parameters
+        ----------
+        node : int
+            Index of the node of interest.
+        mode : string, optional (default: "all")
+            Type of neighbours that will be returned: "all" returns all the
+            neighbours regardless of directionality, "in" returns the
+            in-neighbours (also called predecessors) and "out" retruns the
+            out-neighbours (or successors).
+
+        Returns
+        -------
+        neighbours : set
+            The neighbours of `node`.
+        '''
+        return super().neighbours(node, mode=mode)
+
     def is_spatial(self):
         '''
         Whether the graph is embedded in space (i.e. is a subclass of

--- a/nngt/core/gt_graph.py
+++ b/nngt/core/gt_graph.py
@@ -634,17 +634,18 @@ class _GtGraph(GraphInterface):
 
         Returns
         -------
-        neighbours : tuple
+        neighbours : set
             The neighbours of `node`.
         '''
-        v = self._graph.vertex(node)
+        g = self._graph
+        v = g.vertex(node)
 
-        if mode == "all":
-            return (int(n) for n in v.all_neighbours())
+        if mode == "all" or not g.is_directed():
+            return set(int(n) for n in v.all_neighbours())
         elif mode == "in":
-            return (int(n) for n in v.in_neighbours())
+            return set(int(n) for n in v.in_neighbours())
         elif mode == "out":
-            return (int(n) for n in v.out_neighbours())
+            return set(int(n) for n in v.out_neighbours())
         else:
             raise ArgumentError('''Invalid `mode` argument {}; possible values
                                 are "all", "out" or "in".'''.format(mode))

--- a/nngt/core/ig_graph.py
+++ b/nngt/core/ig_graph.py
@@ -550,17 +550,17 @@ class _IGraph(GraphInterface):
 
         Returns
         -------
-        neighbours : tuple
+        neighbours : set
             The neighbours of `node`.
         '''
         g = self._graph
 
         if mode == "all":
-            return (n for n in g.neighbors(node, mode=3))
+            return set(n for n in g.neighbors(node, mode=3))
         elif mode == "in":
-            return (n for n in g.neighbors(node, mode=2))
+            return set(n for n in g.neighbors(node, mode=2))
         elif mode == "out":
-            return (n for n in g.neighbors(node, mode=1))
+            return set(n for n in g.neighbors(node, mode=1))
 
         raise ArgumentError('Invalid `mode` argument {}; possible values are '
                             '"all", "out" or "in".'.format(mode))

--- a/nngt/core/nngt_graph.py
+++ b/nngt/core/nngt_graph.py
@@ -751,22 +751,23 @@ class _NNGTGraph(GraphInterface):
 
         Returns
         -------
-        neighbours : tuple
+        neighbours : set
             The neighbours of `node`.
         '''
-        neighbours = set()
-
         edges = self.edges_array
 
-        if mode in ("in", "all") or self._graph._directed:
-            neighbours.update(edges[edges[1] == node, 1])
-        elif mode in ("out", "all") and self._graph._directed:
-            neighbours.update(edges[edges[0] == node, 1])
-        else:
-            raise ValueError('''Invalid `mode` argument {}; possible values
-                                are "all", "out" or "in".'''.format(mode))
+        if mode == "all" or not self._graph._directed:
+            neighbours = set(edges[edges[:, 1] == node, 0])
+            return neighbours.union(edges[edges[:, 0] == node, 1])
 
-        return list(neighbours)
+        if mode == "in":
+            return set(edges[edges[:, 1] == node, 0])
+
+        if mode == "out":
+            return set(edges[edges[:, 0] == node, 1])
+
+        raise ValueError(('Invalid `mode` argument {}; possible values'
+                          'are "all", "out" or "in".').format(mode))
 
     def _from_library_graph(self, graph, copy=True):
         ''' Initialize `self._graph` from existing library object. '''

--- a/nngt/core/nx_graph.py
+++ b/nngt/core/nx_graph.py
@@ -22,6 +22,7 @@
 
 from collections import OrderedDict, deque
 from copy import deepcopy
+from itertools import chain
 import logging
 import sys
 
@@ -646,18 +647,22 @@ class _NxGraph(GraphInterface):
 
         Returns
         -------
-        neighbours : numpy array
+        neighbours : set
             The neighbours of `node`.
         '''
         g = self._graph
 
+        # special case for undirected
+        if not g.is_directed():
+            return set(g.neighbors(node))
+
         if mode == "all":
-            return np.fromiter(
-                chain(g.successors(node), g.predecessors(node)), dtype=int)
+            # for directed graphs, neighbors ~ successors
+            return set(g.successors(node)).union(g.predecessors(node))
         elif mode == "in":
-            return np.fromiter(g.predecessors(node), dtype=int)
+            return set(g.predecessors(node))
         elif mode == "out":
-            return np.fromiter(g.successors(node), dtype=int)
+            return set(g.successors(node))
 
         raise ArgumentError('Invalid `mode` argument {}; possible values are '
                             '"all", "out" or "in".'.format(mode))

--- a/nngt/core/nx_graph.py
+++ b/nngt/core/nx_graph.py
@@ -655,9 +655,9 @@ class _NxGraph(GraphInterface):
             return np.fromiter(
                 chain(g.successors(node), g.predecessors(node)), dtype=int)
         elif mode == "in":
-            return np.fromiter(self.predecessors(node), dtype=int)
+            return np.fromiter(g.predecessors(node), dtype=int)
         elif mode == "out":
-            return np.fromiter(self.successors(node), dtype=int)
+            return np.fromiter(g.successors(node), dtype=int)
 
         raise ArgumentError('Invalid `mode` argument {}; possible values are '
                             '"all", "out" or "in".'.format(mode))

--- a/testing/test_analysis.py
+++ b/testing/test_analysis.py
@@ -10,10 +10,12 @@
 """ Test the graph analysis functions """
 
 import numpy as np
+import pytest
 
 import nngt
 
 
+@pytest.mark.skipif(nngt.get_config("backend") == "nngt")
 def test_directed_clustering():
     '''
     Check directed clustering.

--- a/testing/test_analysis.py
+++ b/testing/test_analysis.py
@@ -1,0 +1,31 @@
+#!/usr/bin/env python
+#-*- coding:utf-8 -*-
+
+# test_analysis.py
+
+# This file is part of the NNGT module
+# Distributed as a free software, in the hope that it will be useful, under the
+# terms of the GNU General Public License.
+
+""" Test the graph analysis functions """
+
+import numpy as np
+
+import nngt
+
+
+def test_directed_clustering():
+    '''
+    Check directed clustering.
+    (should return undirected value if graph is not directed)
+    '''
+    g = nngt.generation.erdos_renyi(avg_deg=10, nodes=100, directed=False)
+
+    ccu = nngt.analysis.undirected_local_clustering(g)
+    cc  = nngt.analysis.local_clustering(g)
+
+    assert np.all(np.isclose(cc, ccu))
+
+
+if __name__ == "__main__":
+    test_directed_clustering()

--- a/testing/test_analysis.py
+++ b/testing/test_analysis.py
@@ -15,7 +15,7 @@ import pytest
 import nngt
 
 
-@pytest.mark.skipif(nngt.get_config("backend") == "nngt")
+@pytest.mark.skipif(nngt.get_config("backend") == "nngt", reason="unsupported")
 def test_directed_clustering():
     '''
     Check directed clustering.

--- a/testing/test_basics.py
+++ b/testing/test_basics.py
@@ -154,7 +154,7 @@ def test_graph_copy():
     assert g.shape is not copy.shape
 
 
-def test_degrees():
+def test_degrees_neighbors():
     '''
     Check ``Graph.get_degrees`` method.
     '''
@@ -177,9 +177,15 @@ def test_degrees():
     assert np.all(g.get_degrees(mode="out") == out_degrees)
     assert np.all(g.get_degrees() == tot_degrees)
 
-    assert np.all(np.isclose(g.get_degrees(mode="in", weights=True), in_strengths))
-    assert np.all(np.isclose(g.get_degrees(mode="out", weights=True), out_strengths))
+    assert np.all(
+        np.isclose(g.get_degrees(mode="in", weights=True), in_strengths))
+    assert np.all(
+        np.isclose(g.get_degrees(mode="out", weights=True), out_strengths))
     assert np.all(np.isclose(g.get_degrees(weights="weight"), tot_strengths))
+
+    assert g.neighbours(3, "in")  == {0, 1}
+    assert g.neighbours(3, "out") == {2, 4}
+    assert g.neighbours(3, "all") == {0, 1, 2, 4}
 
     # UNDIRECTED
     g = nngt.Graph(5, directed=False)
@@ -189,9 +195,15 @@ def test_degrees():
     assert np.all(g.get_degrees(mode="out") == tot_degrees)
     assert np.all(g.get_degrees() == tot_degrees)
 
-    assert np.all(np.isclose(g.get_degrees(mode="in", weights=True), tot_strengths))
-    assert np.all(np.isclose(g.get_degrees(mode="out", weights=True), tot_strengths))
+    assert np.all(
+        np.isclose(g.get_degrees(mode="in", weights=True), tot_strengths))
+    assert np.all(
+        np.isclose(g.get_degrees(mode="out", weights=True), tot_strengths))
     assert np.all(np.isclose(g.get_degrees(weights="weight"), tot_strengths))
+
+    assert g.neighbours(3, "in")  == {0, 1, 2, 4}
+    assert g.neighbours(3, "out") == {0, 1, 2, 4}
+    assert g.neighbours(3, "all") == {0, 1, 2, 4}
 
 
 def test_directed_adjacency():
@@ -362,7 +374,7 @@ if __name__ == "__main__":
     test_config()
     test_new_node_attr()
     test_graph_copy()
-    test_degrees()
+    test_degrees_neighbors()
 
     if not nngt.get_config('mpi'):
         test_node_creation()


### PR DESCRIPTION
This PR corrects ``Graph.neighbours`` for undirected networks and the function now returns a ``set``.
Also correct wrong ``graph`` attribute access in ``local_clustering`` and for "networkx" backend.
Tests were added.