### PR TITLE
Automatically add edge distances for SpatialGraph

### DIFF
--- a/nngt/core/gt_graph.py
+++ b/nngt/core/gt_graph.py
@@ -601,7 +601,7 @@ class _GtGraph(GraphInterface):
                 dtype = self.get_attribute_type(k)
                 if dtype == "string":
                     attributes[k] = ["" for _ in range(num_edges)]
-                elif dtype == "double" and k != "weight":
+                elif dtype == "double" and k not in ("weight", "distance"):
                     attributes[k] = [np.NaN for _ in range(num_edges)]
 
         # check edges

--- a/nngt/core/gt_graph.py
+++ b/nngt/core/gt_graph.py
@@ -29,7 +29,7 @@ import scipy.sparse as ssp
 
 import nngt
 from nngt.lib import InvalidArgument, BWEIGHT, nonstring_container, is_integer
-from nngt.lib.connect_tools import _cleanup_edges
+from nngt.lib.connect_tools import _cleanup_edges, _set_dist_new_edges
 from nngt.lib.converters import _to_np_array
 from nngt.lib.graph_helpers import _get_dtype, _get_gt_weights
 from nngt.lib.logger import _log_message
@@ -528,6 +528,9 @@ class _GtGraph(GraphInterface):
 
             g.add_edge(source, target, add_missing=False)
 
+            # check distance
+            _set_dist_new_edges(new_attr, self, [edge])
+
             # set the attributes
             self._attr_new_edges([(source, target)], attributes=attributes)
         else:
@@ -611,6 +614,9 @@ class _GtGraph(GraphInterface):
         else:
             edge_list = np.asarray(edge_list)
             new_attr  = attributes
+
+        # check distance
+        _set_dist_new_edges(new_attr, self, edge_list)
 
         # create the edges
         if len(edge_list):

--- a/nngt/core/gt_graph.py
+++ b/nngt/core/gt_graph.py
@@ -29,7 +29,8 @@ import scipy.sparse as ssp
 
 import nngt
 from nngt.lib import InvalidArgument, BWEIGHT, nonstring_container, is_integer
-from nngt.lib.connect_tools import _cleanup_edges, _set_dist_new_edges
+from nngt.lib.connect_tools import (_cleanup_edges, _set_dist_new_edges,
+                                    _set_default_edge_attributes)
 from nngt.lib.converters import _to_np_array
 from nngt.lib.graph_helpers import _get_dtype, _get_gt_weights
 from nngt.lib.logger import _log_message
@@ -502,13 +503,7 @@ class _GtGraph(GraphInterface):
 
         attributes = {} if attributes is None else deepcopy(attributes)
 
-        for k in self.edge_attributes:
-            if k not in attributes:
-                dtype = self.get_attribute_type(k)
-                if dtype == "string":
-                    attributes[k] = [""]
-                elif dtype == "double" and k != "weight":
-                    attributes[k] = [np.NaN]
+        _set_default_edge_attributes(self, attributes, num_edges=1)
 
         # check that the edge does not already exist and that nodes are valid
         try:
@@ -529,7 +524,7 @@ class _GtGraph(GraphInterface):
             g.add_edge(source, target, add_missing=False)
 
             # check distance
-            _set_dist_new_edges(new_attr, self, [edge])
+            _set_dist_new_edges(attributes, self, [(source, target)])
 
             # set the attributes
             self._attr_new_edges([(source, target)], attributes=attributes)
@@ -595,14 +590,7 @@ class _GtGraph(GraphInterface):
             raise InvalidArgument("Some nodes do no exist.")
 
         # set default values for attributes that were not passed
-        # (only string and double, others are handled correctly by default)
-        for k in self.edge_attributes:
-            if k not in attributes:
-                dtype = self.get_attribute_type(k)
-                if dtype == "string":
-                    attributes[k] = ["" for _ in range(num_edges)]
-                elif dtype == "double" and k not in ("weight", "distance"):
-                    attributes[k] = [np.NaN for _ in range(num_edges)]
+        _set_default_edge_attributes(self, attributes, num_edges)
 
         # check edges
         new_attr = None

--- a/nngt/core/ig_graph.py
+++ b/nngt/core/ig_graph.py
@@ -29,7 +29,7 @@ import scipy.sparse as ssp
 
 import nngt
 from nngt.lib import InvalidArgument, nonstring_container, BWEIGHT, is_integer
-from nngt.lib.connect_tools import _cleanup_edges
+from nngt.lib.connect_tools import _cleanup_edges, _set_dist_new_edges
 from nngt.lib.graph_helpers import _get_dtype, _get_ig_weights
 from nngt.lib.converters import _np_dtype, _to_np_array
 from nngt.lib.logger import _log_message
@@ -516,6 +516,9 @@ class _IGraph(GraphInterface):
             new_attr = attributes
 
         self._graph.add_edges(edge_list)
+
+        # check distance
+        _set_dist_new_edges(new_attr, self, edge_list)
 
         # call parent function to set the attributes
         self._attr_new_edges(edge_list, attributes=new_attr)

--- a/nngt/core/ig_graph.py
+++ b/nngt/core/ig_graph.py
@@ -29,7 +29,8 @@ import scipy.sparse as ssp
 
 import nngt
 from nngt.lib import InvalidArgument, nonstring_container, BWEIGHT, is_integer
-from nngt.lib.connect_tools import _cleanup_edges, _set_dist_new_edges
+from nngt.lib.connect_tools import (_cleanup_edges, _set_dist_new_edges,
+                                    _set_default_edge_attributes)
 from nngt.lib.graph_helpers import _get_dtype, _get_ig_weights
 from nngt.lib.converters import _np_dtype, _to_np_array
 from nngt.lib.logger import _log_message
@@ -420,17 +421,6 @@ class _IGraph(GraphInterface):
         '''
         attributes = {} if attributes is None else deepcopy(attributes)
 
-        # set default values for attributes that were not passed
-        for k in self.edge_attributes:
-            if k not in attributes:
-                dtype = self.get_attribute_type(k)
-                if dtype == "string":
-                    attributes[k] = [""]
-                elif dtype == "double" and k != "weight":
-                    attributes[k] = [np.NaN]
-                elif dtype == "int":
-                    attributes[k] = [0]
-
         if source == target:
             if not ignore and not self_loop:
                 raise InvalidArgument("Trying to add a self-loop.")
@@ -495,15 +485,7 @@ class _IGraph(GraphInterface):
             raise InvalidArgument("Some nodes do no exist.")
 
         # set default values for attributes that were not passed
-        for k in self.edge_attributes:
-            if k not in attributes:
-                dtype = self.get_attribute_type(k)
-                if dtype == "string":
-                    attributes[k] = ["" for _ in range(num_edges)]
-                elif dtype == "double" and k != "weight":
-                    attributes[k] = [np.NaN for _ in range(num_edges)]
-                elif dtype == "int":
-                    attributes[k] = [0 for _ in range(num_edges)]
+        _set_default_edge_attributes(self, attributes, num_edges)
 
         # check edges
         new_attr = None

--- a/nngt/core/nngt_graph.py
+++ b/nngt/core/nngt_graph.py
@@ -30,7 +30,8 @@ from scipy.sparse import coo_matrix, lil_matrix
 
 import nngt
 from nngt.lib import InvalidArgument, nonstring_container, is_integer
-from nngt.lib.connect_tools import _cleanup_edges, _set_dist_new_edges
+from nngt.lib.connect_tools import (_cleanup_edges, _set_dist_new_edges,
+                                    _set_default_edge_attributes)
 from nngt.lib.graph_helpers import _get_edge_attr, _get_dtype
 from nngt.lib.converters import _np_dtype, _to_np_array
 from nngt.lib.logger import _log_message
@@ -511,17 +512,7 @@ class _NNGTGraph(GraphInterface):
         attributes = {} if attributes is None else deepcopy(attributes)
 
         # set default values for attributes that were not passed
-        for k in self.edge_attributes:
-            if k not in attributes:
-                dtype = self.get_attribute_type(k)
-                if dtype == "string":
-                    attributes[k] = [""]
-                elif dtype == "double" and k != "weight":
-                    attributes[k] = [np.NaN]
-                elif dtype == "int":
-                    attributes[k] = [0]
-                else:
-                    attributes[k] = [None]
+        _set_default_edge_attributes(self, attributes, num_edges=1)
 
         # check that the edge does not already exist
         edge = (source, target)
@@ -548,7 +539,7 @@ class _NNGTGraph(GraphInterface):
             g._in_deg[target]  += 1
 
             # check distance
-            _set_dist_new_edges(new_attr, self, [edge])
+            _set_dist_new_edges(attributes, self, [edge])
 
             # attributes
             self._attr_new_edges([(source, target)], attributes=attributes)
@@ -619,18 +610,7 @@ class _NNGTGraph(GraphInterface):
         g = self._graph
 
         # set default values for attributes that were not passed
-        for k in self.edge_attributes:
-            if k not in attributes:
-                dtype = self.get_attribute_type(k)
-                if dtype == "string":
-                    attributes[k] = ["" for _ in range(num_edges)]
-                elif dtype == "double":
-                    if k != "weight":
-                        attributes[k] = [np.NaN for _ in range(num_edges)]
-                elif dtype == "int":
-                    attributes[k] = [0 for _ in range(num_edges)]
-                else:
-                    attributes[k] = [None for _ in range(num_edges)]
+        _set_default_edge_attributes(self, attributes, num_edges)
 
         # check that all nodes exist
         if np.max(edge_list) >= self.node_nb():

--- a/nngt/core/nngt_graph.py
+++ b/nngt/core/nngt_graph.py
@@ -30,7 +30,7 @@ from scipy.sparse import coo_matrix, lil_matrix
 
 import nngt
 from nngt.lib import InvalidArgument, nonstring_container, is_integer
-from nngt.lib.connect_tools import _cleanup_edges
+from nngt.lib.connect_tools import _cleanup_edges, _set_dist_new_edges
 from nngt.lib.graph_helpers import _get_edge_attr, _get_dtype
 from nngt.lib.converters import _np_dtype, _to_np_array
 from nngt.lib.logger import _log_message
@@ -547,6 +547,9 @@ class _NNGTGraph(GraphInterface):
             g._out_deg[source] += 1
             g._in_deg[target]  += 1
 
+            # check distance
+            _set_dist_new_edges(new_attr, self, [edge])
+
             # attributes
             self._attr_new_edges([(source, target)], attributes=attributes)
 
@@ -671,6 +674,9 @@ class _NNGTGraph(GraphInterface):
 
                 g._out_deg[e[1]] += 1
                 g._in_deg[e[0]]  += 1
+
+        # check distance
+        _set_dist_new_edges(new_attr, self, edge_list)
 
         # call parent function to set the attributes
         self._attr_new_edges(edge_list, attributes=new_attr)

--- a/nngt/core/nx_graph.py
+++ b/nngt/core/nx_graph.py
@@ -31,7 +31,7 @@ import scipy.sparse as ssp
 
 import nngt
 from nngt.lib import InvalidArgument, BWEIGHT, nonstring_container, is_integer
-from nngt.lib.connect_tools import _cleanup_edges
+from nngt.lib.connect_tools import _cleanup_edges, _set_dist_new_edges
 from nngt.lib.graph_helpers import _get_dtype, _get_nx_weights
 from nngt.lib.converters import _np_dtype, _to_np_array
 from nngt.lib.logger import _log_message
@@ -506,6 +506,9 @@ class _NxGraph(GraphInterface):
             if self.is_weighted() and "weight" not in attributes:
                 attributes["weight"] = 1.
 
+            # check distance
+            _set_dist_new_edges(attributes, self, [(source, target)])
+
             g.add_edge(source, target)
 
             g[source][target]["eid"] = g.number_of_edges() - 1
@@ -607,6 +610,9 @@ class _NxGraph(GraphInterface):
 
             # create the edges with an eid attribute
             g.add_weighted_edges_from(arr_edges, weight="eid")
+
+            # check distance
+            _set_dist_new_edges(new_attr, self, edge_list)
 
             # call parent function to set the attributes
             self._attr_new_edges(edge_list, attributes=new_attr)

--- a/nngt/core/nx_graph.py
+++ b/nngt/core/nx_graph.py
@@ -31,7 +31,8 @@ import scipy.sparse as ssp
 
 import nngt
 from nngt.lib import InvalidArgument, BWEIGHT, nonstring_container, is_integer
-from nngt.lib.connect_tools import _cleanup_edges, _set_dist_new_edges
+from nngt.lib.connect_tools import (_cleanup_edges, _set_dist_new_edges,
+                                    _set_default_edge_attributes)
 from nngt.lib.graph_helpers import _get_dtype, _get_nx_weights
 from nngt.lib.converters import _np_dtype, _to_np_array
 from nngt.lib.logger import _log_message
@@ -410,13 +411,14 @@ class _NxGraph(GraphInterface):
             old_pos      = self._pos
             self._pos    = np.full((self.node_nb(), 2), np.NaN)
             num_existing = len(old_pos) if old_pos is not None else 0
+
             if num_existing != 0:
-                self._pos[:num_existing, :] = old_pos
+                self._pos[:num_existing] = old_pos
 
         if positions is not None and len(positions):
             assert self.is_spatial(), \
                 "`positions` argument requires a SpatialGraph/SpatialNetwork."
-            self._pos[new_nodes, :] = positions
+            self._pos[new_nodes] = positions
 
         if groups is not None:
             assert self.is_network(), \
@@ -472,15 +474,7 @@ class _NxGraph(GraphInterface):
             raise InvalidArgument("`source` or `target` does not exist.")
 
         # set default values for attributes that were not passed
-        for k in self.edge_attributes:
-            if k not in attributes:
-                dtype = self.get_attribute_type(k)
-                if dtype == "string":
-                    attributes[k] = [""]
-                elif dtype == "double" and k != "weight":
-                    attributes[k] = [np.NaN]
-                elif dtype == "int":
-                    attributes[k] = [0]
+        _set_default_edge_attributes(self, attributes, num_edges=1)
 
         if g.has_edge(source, target):
             if not ignore:
@@ -576,15 +570,7 @@ class _NxGraph(GraphInterface):
                                           "available with networkx.")
 
         # set default values for attributes that were not passed
-        for k in self.edge_attributes:
-            if k not in attributes:
-                dtype = self.get_attribute_type(k)
-                if dtype == "string":
-                    attributes[k] = ["" for _ in range(num_edges)]
-                elif dtype == "double" and k != "weight":
-                    attributes[k] = [np.NaN for _ in range(num_edges)]
-                elif dtype == "int":
-                    attributes[k] = [0 for _ in range(num_edges)]
+        _set_default_edge_attributes(self, attributes, num_edges)
 
         # check edges
         new_attr = None

--- a/nngt/core/spatial_graph.py
+++ b/nngt/core/spatial_graph.py
@@ -116,9 +116,13 @@ class SpatialGraph(Graph):
         Create the positions of the neurons from the graph `shape` attribute
         and computes the connections distances.
         '''
+        positions = None if positions is None else np.asarray(positions)
+
         self.new_edge_attribute('distance', 'double')
-        if positions is not None and positions.shape[0] != self.node_nb():
+
+        if positions is not None and len(positions) != self.node_nb():
             raise InvalidArgument("Wrong number of neurons in `positions`.")
+
         if shape is not None:
             shape.set_parent(self)
             self._shape = shape
@@ -146,8 +150,11 @@ class SpatialGraph(Graph):
             else:
                 minx, maxx = np.min(positions[:, 0]), np.max(positions[:, 0])
                 miny, maxy = np.min(positions[:, 1]), np.max(positions[:, 1])
+
                 height, width = 1.01*(maxy - miny), 1.01*(maxx - minx)
+
                 centroid = (0.5*(maxx + minx), 0.5*(maxy + miny))
+
                 self._shape = nngt.geometry.Shape.rectangle(
                     height, width, centroid=centroid, parent=self)
 

--- a/nngt/core/spatial_graph.py
+++ b/nngt/core/spatial_graph.py
@@ -168,7 +168,7 @@ class SpatialGraph(Graph):
 
     def get_positions(self, neurons=None):
         '''
-        Returns the neurons' positions as a (N, 2) array.
+        Returns a copy of the neurons' positions as a (N, 2) array.
 
         Parameters
         ----------
@@ -176,6 +176,10 @@ class SpatialGraph(Graph):
             List of the neurons for which the position should be returned.
         '''
         if neurons is not None:
+            if isinstance(neurons, tuple):
+                # numpy mulitple slicing does not work with tuples
+                neurons = list(neurons)
+
             return np.array(self._pos[neurons])
 
         return np.array(self._pos)

--- a/nngt/generation/connect_algorithms.py
+++ b/nngt/generation/connect_algorithms.py
@@ -23,7 +23,6 @@
 import logging
 import numpy as np
 import scipy.sparse as ssp
-from scipy.spatial.distance import cdist
 from numpy.random import randint
 
 import nngt

--- a/nngt/generation/connectors.py
+++ b/nngt/generation/connectors.py
@@ -119,9 +119,8 @@ def connect_nodes(network, sources, targets, graph_model, density=None,
         attr['weight'] = kwargs['weights']
     if 'delays' in kwargs:
         attr['delay'] = kwargs['delays']
-    if network.is_spatial():
-        if len(distance) > 0:
-            attr['distance'] = distance
+    if network.is_spatial() and distance:
+        attr['distance'] = distance
 
     # call only on root process (for mpi) unless using distributed backend
     if nngt.on_master_process() or nngt.get_config("backend") == "nngt":

--- a/nngt/generation/graph_connectivity.py
+++ b/nngt/generation/graph_connectivity.py
@@ -249,8 +249,6 @@ def from_degree_list(degrees, degree_type='in', weighted=True,
             graph_dl.new_edges(ia_edges, check_duplicates=False,
                                check_self_loops=False, check_existing=False)
 
-        
-
     graph_dl._graph_type = "from_{}_degree_list".format(degree_type)
 
     return graph_dl

--- a/nngt/generation/graph_connectivity.py
+++ b/nngt/generation/graph_connectivity.py
@@ -249,6 +249,8 @@ def from_degree_list(degrees, degree_type='in', weighted=True,
             graph_dl.new_edges(ia_edges, check_duplicates=False,
                                check_self_loops=False, check_existing=False)
 
+        
+
     graph_dl._graph_type = "from_{}_degree_list".format(degree_type)
 
     return graph_dl

--- a/nngt/lib/connect_tools.py
+++ b/nngt/lib/connect_tools.py
@@ -356,13 +356,13 @@ def max_proba_dist_rule(rule, scale, max_proba, pos_src, pos_targets,
 
 def _set_dist_new_edges(new_attr, graph, edge_list):
     ''' Add the distances to the edge attributes '''
-    if graph.is_spatial():
+    if graph.is_spatial() and "distance" not in new_attr:
         if len(edge_list) == 1:
             positions = graph.get_positions(edge_list[0])
             new_attr["distance"] = cdist([positions[0]], [positions[1]])[0][0]
         else:
             positions = graph.get_positions()
             mat = cdist(positions, positions)
-            distances = [mat[*e] for e in edges]
+            distances = [mat[e[0], e[1]] for e in edge_list]
 
-            new_attr["distance"] = values
+            new_attr["distance"] = distances

--- a/nngt/lib/connect_tools.py
+++ b/nngt/lib/connect_tools.py
@@ -352,3 +352,17 @@ def max_proba_dist_rule(rule, scale, max_proba, pos_src, pos_targets,
         return max_proba*np.divide(scale - dist_tmp, scale).clip(min=0.)
     else:
         raise InvalidArgument('Unknown rule "' + rule + '".')
+
+
+def _set_dist_new_edges(new_attr, graph, edge_list):
+    ''' Add the distances to the edge attributes '''
+    if graph.is_spatial():
+        if len(edge_list) == 1:
+            positions = graph.get_positions(edge_list[0])
+            new_attr["distance"] = cdist([positions[0]], [positions[1]])[0][0]
+        else:
+            positions = graph.get_positions()
+            mat = cdist(positions, positions)
+            distances = [mat[*e] for e in edges]
+
+            new_attr["distance"] = values

--- a/nngt/lib/connect_tools.py
+++ b/nngt/lib/connect_tools.py
@@ -358,7 +358,7 @@ def _set_dist_new_edges(new_attr, graph, edge_list):
     ''' Add the distances to the edge attributes '''
     if graph.is_spatial() and "distance" not in new_attr:
         if len(edge_list) == 1:
-            positions = graph.get_positions(edge_list[0])
+            positions = graph.get_positions(list(edge_list[0]))
             new_attr["distance"] = cdist([positions[0]], [positions[1]])[0][0]
         else:
             positions = graph.get_positions()
@@ -366,3 +366,20 @@ def _set_dist_new_edges(new_attr, graph, edge_list):
             distances = [mat[e[0], e[1]] for e in edge_list]
 
             new_attr["distance"] = distances
+
+
+def _set_default_edge_attributes(g, attributes, num_edges):
+    ''' Set default edge attributes values '''
+    for k in g.edge_attributes:
+        skip = k in ("weight", "distance")
+
+        if k not in attributes:
+            dtype = g.get_attribute_type(k)
+            if dtype == "string":
+                attributes[k] = ["" for _ in range(num_edges)]
+            elif dtype == "double" and not skip:
+                attributes[k] = [np.NaN for _ in range(num_edges)]
+            elif dtype == "int":
+                attributes[k] = [0 for _ in range(num_edges)]
+            elif not skip:
+                attributes[k] = [None for _ in range(num_edges)]

--- a/testing/test_generation2.py
+++ b/testing/test_generation2.py
@@ -327,6 +327,11 @@ def test_distances():
 
     assert np.array_equal(dist, expected)
 
+    g.new_node(positions=[(4, 0)])
+    g.new_edge(1, 4)
+
+    assert g.get_edge_attributes((1, 4), "distance") == 3
+
     # distance rule
     g = ng.distance_rule(2.5, rule="lin", nodes=num_nodes, avg_deg=2,
                          positions=pos)
@@ -339,15 +344,34 @@ def test_distances():
     assert np.all(dist < 3)
 
     # using the connector functions
+    num_nodes = 20
+
+    pop = nngt.NeuralPop.exc_and_inhib(num_nodes)
+    pos = np.array([(i, 0) for i in range(num_nodes)])
+
+    net = nngt.SpatialNetwork(pop, positions=pos)
+
+    inh = pop["inhibitory"]
+    exc = pop["excitatory"]
+
+    ng.connect_groups(net, exc, pop, "erdos_renyi", avg_deg=5)
+    ng.connect_groups(net, inh, pop, "random_scale_free", in_exp=2.1,
+                      out_exp=2.1, avg_deg=5)
+
+    dist = net.edge_attributes["distance"]
+
+    expected = np.abs(np.diff(net.edges_array, axis=1)).ravel()
+
+    assert np.array_equal(dist, expected)
 
 
 if __name__ == "__main__":
     if not nngt.get_config("mpi"):
-        # ~ test_newman_watts()
-        # ~ test_from_degree_list()
-        # ~ test_total_undirected_connectivities()
-        # ~ test_watts_strogatz()
-        # ~ test_all_to_all()
+        test_newman_watts()
+        test_from_degree_list()
+        test_total_undirected_connectivities()
+        test_watts_strogatz()
+        test_all_to_all()
         test_distances()
 
     if nngt.get_config("mpi"):

--- a/testing/test_generation2.py
+++ b/testing/test_generation2.py
@@ -308,6 +308,7 @@ def test_all_to_all():
                           [(0, 1), (0, 2), (0, 3), (1, 2), (1, 3)])
 
 
+@pytest.mark.mpi_skip
 def test_distances():
     ''' Check that distances are properly generated for SpatialGraphs '''
     # simple graph

--- a/testing/test_generation2.py
+++ b/testing/test_generation2.py
@@ -308,6 +308,11 @@ def test_all_to_all():
                           [(0, 1), (0, 2), (0, 3), (1, 2), (1, 3)])
 
 
+def test_distances():
+    ''' Check that distances are properly generated for SpatialGraphs '''
+    pass
+
+
 if __name__ == "__main__":
     if not nngt.get_config("mpi"):
         test_newman_watts()

--- a/testing/test_generation2.py
+++ b/testing/test_generation2.py
@@ -310,16 +310,45 @@ def test_all_to_all():
 
 def test_distances():
     ''' Check that distances are properly generated for SpatialGraphs '''
-    pass
+    # simple graph
+    num_nodes = 4
+
+    pos = [(0, 0), (1, 0), (2, 0), (3, 0)]
+    
+    g = nngt.SpatialGraph(num_nodes, positions=pos)
+
+    edges = [(0, 1), (0, 3), (1, 2), (2, 3)]
+
+    g.new_edges(edges)
+
+    dist = g.edge_attributes["distance"]
+
+    expected = np.abs(np.diff(g.edges_array, axis=1)).ravel()
+
+    assert np.array_equal(dist, expected)
+
+    # distance rule
+    g = ng.distance_rule(2.5, rule="lin", nodes=num_nodes, avg_deg=2,
+                         positions=pos)
+
+    dist = g.edge_attributes["distance"]
+
+    expected = np.abs(np.diff(g.edges_array, axis=1)).ravel()
+
+    assert np.array_equal(dist, expected)
+    assert np.all(dist < 3)
+
+    # using the connector functions
 
 
 if __name__ == "__main__":
     if not nngt.get_config("mpi"):
-        test_newman_watts()
-        test_from_degree_list()
-        test_total_undirected_connectivities()
-        test_watts_strogatz()
-        test_all_to_all()
+        # ~ test_newman_watts()
+        # ~ test_from_degree_list()
+        # ~ test_total_undirected_connectivities()
+        # ~ test_watts_strogatz()
+        # ~ test_all_to_all()
+        test_distances()
 
     if nngt.get_config("mpi"):
         test_mpi_from_degree_list()


### PR DESCRIPTION
Fixes #76 by automatically adding the correct distance to new edges if the graph is spatial, even if the generation algorithm does not compute the distances.