### PR TITLE
Improve graph drawing, connectors, and make_spatial

### DIFF
--- a/doc/examples/introductory_tutorial.py
+++ b/doc/examples/introductory_tutorial.py
@@ -92,14 +92,14 @@ g3.new_node_attribute('size', 'double',
 print(g3.node_attributes['size'][:5], '\n')
 
 # edges attributes
-edges = g3.new_edges(np.random.randint(0, 50, (10, 2)))
+edges = g3.new_edges(np.random.randint(0, 50, (10, 2)), ignore_invalid=True)
 g3.new_edge_attribute('rank', 'int')
 g3.set_edge_attribute('rank', val=2, edges=edges[:3, :])
 print(g3.edge_attributes['rank'], '\n')
 
 # check default values
 e = g3.new_edge(99, 98)
-g3.new_edges(np.random.randint(50, 100, (5, 2)))
+g3.new_edges(np.random.randint(50, 100, (5, 2)), ignore_invalid=True)
 print(g3.edge_attributes['rank'], '\n')
 
 

--- a/nngt/generation/connectors.py
+++ b/nngt/generation/connectors.py
@@ -124,10 +124,10 @@ def connect_nodes(network, sources, targets, graph_model, density=None,
 
     # call only on root process (for mpi) unless using distributed backend
     if nngt.on_master_process() or nngt.get_config("backend") == "nngt":
-        network.new_edges(elist, attributes=attr, check_duplicates=False,
-                          check_self_loops=False,
-                          check_existing=check_existing,
-                          ignore_invalid=ignore_invalid)
+        elist = network.new_edges(
+            elist, attributes=attr, check_duplicates=False,
+            check_self_loops=False, check_existing=check_existing,
+            ignore_invalid=ignore_invalid)
 
     if not network._graph_type.endswith('_connect'):
         network._graph_type += "_nodes_connect"

--- a/nngt/lib/connect_tools.py
+++ b/nngt/lib/connect_tools.py
@@ -32,11 +32,10 @@ __all__ = [
 
 
 def _set_options(graph, population, shape, positions):
-    #~ if issubclass(graph.__class__, nngt.Network):
-        #~ Connections.delays(graph)
+    ''' Make a graph a network or spatial '''
     if population is not None:
         nngt.Graph.make_network(graph, population)
-    if shape is not None:
+    if shape is not None or positions is not None:
         nngt.Graph.make_spatial(graph, shape, positions)
 
 

--- a/nngt/plot/custom_plt.py
+++ b/nngt/plot/custom_plt.py
@@ -38,7 +38,7 @@ def palette_discrete(numbers=None):
         return pal(numbers)
 
 # markers list
-markers = itertools.cycle([m for m in MS().filled_markers if m != '.'])
+markers = [m for m in MS().filled_markers if m != '.']
 
 if nngt._config["color_lib"] == "seaborn":
     try:

--- a/nngt/plot/plt_networks.py
+++ b/nngt/plot/plt_networks.py
@@ -71,9 +71,9 @@ def draw_network(network, nsize="total-degree", ncolor="group", nshape="o",
                  threshold=0.5, decimate_connections=None, spatial=True,
                  restrict_sources=None, restrict_targets=None,
                  restrict_nodes=None, restrict_edges=None,
-                 show_environment=True, fast=True, size=(600, 600), xlims=None,
-                 ylims=None, dpi=75, axis=None, colorbar=False, cb_label=None,
-                 layout=None, show=False, **kwargs):
+                 show_environment=True, fast=False, size=(600, 600),
+                 xlims=None, ylims=None, dpi=75, axis=None, colorbar=False,
+                 cb_label=None, layout=None, show=False, **kwargs):
     '''
     Draw a given graph/network.
 
@@ -129,10 +129,10 @@ def draw_network(network, nsize="total-degree", ncolor="group", nshape="o",
     show_environment : bool, optional (default: True)
         Plot the environment if the graph is spatial.
     fast : bool, optional (default: False)
-        Use a faster algorithm to plot the edges. This method leads to less
-        pretty plots and zooming on the graph will make the edges start or
-        ending in places that will differ more or less strongly from the actual
-        node positions.
+        Use a faster algorithm to plot the edges. Zooming on the drawing made
+        using this method leaves the size of the nodes and edges unchanged, it
+        is therefore not recommended when size consistency matters, e.g. for
+        some spatial representations.
     size : tuple of ints, optional (default: (600,600))
         (width, height) tuple for the canvas size (in px).
     dpi : int, optional (default: 75)

--- a/nngt/plot/plt_networks.py
+++ b/nngt/plot/plt_networks.py
@@ -577,8 +577,9 @@ def library_draw(network, nsize="total-degree", ncolor="group", nshape="o",
                  ealpha=0.5, max_nsize=5., max_esize=2., curved_edges=False,
                  threshold=0.5, decimate_connections=None, spatial=True,
                  restrict_sources=None, restrict_targets=None,
-                 restrict_nodes=None, show_environment=True, size=(600, 600),
-                 xlims=None, ylims=None, dpi=75, axis=None, colorbar=False,
+                 restrict_nodes=None, restrict_edges=None,
+                 show_environment=True, size=(600, 600), xlims=None,
+                 ylims=None, dpi=75, axis=None, colorbar=False,
                  show_labels=False, layout=None, show=False, **kwargs):
     '''
     Draw a given :class:`~nngt.Graph` using the underlying library's drawing
@@ -633,6 +634,8 @@ def library_draw(network, nsize="total-degree", ncolor="group", nshape="o",
         Only draw edges ending on a restricted set of target nodes.
     restrict_nodes : str, group, or list, optional (default: plot all nodes)
         Only draw a subset of nodes.
+    restrict_edges : list of edges, optional (default: all)
+        Only draw a subset of edges.
     show_environment : bool, optional (default: True)
         Plot the environment if the graph is spatial.
     fast : bool, optional (default: False)
@@ -704,7 +707,7 @@ def library_draw(network, nsize="total-degree", ncolor="group", nshape="o",
     # shize and shape
     markers, nsize, esize = _node_edge_shape_size(
         network, nshape, nsize, max_nsize, esize, max_esize, restrict_nodes,
-        size, threshold)
+        restrict_edges, size, threshold)
 
     # node color information
     default_ncmap = (palette_discrete() if ncolor == "group"
@@ -796,8 +799,21 @@ def library_draw(network, nsize="total-degree", ncolor="group", nshape="o",
             "pen_width": _to_gt_prop(graph, esize, None, ptype='edge'),
         }
 
+        if restrict_edges is not None:
+            efilt = network.graph.new_ep(
+                "bool", vals=np.zeros(network.edge_nb(), dtype=bool))
+            eids = [network.edge_id(e) for e in restrict_edges]
+
+            efilt.a[eids] = 1
+
+            network.graph.set_edge_filter(efilt)
+
         graph_draw(network.graph, pos=pos, vprops=vprops, eprops=eprops,
                    output_size=size, mplfig=axis)
+
+        if restrict_edges is not None:
+            # clear edge filter
+            network.graph.set_edge_filter(None)
     elif nngt.get_config("backend") == "networkx":
         import networkx as nx
 
@@ -819,10 +835,12 @@ def library_draw(network, nsize="total-degree", ncolor="group", nshape="o",
 
         nborder_width = _increase_nx_size(nborder_width, 2)
 
+        edges = None if restrict_edges is None else list(restrict_edges)
+
         nx.draw_networkx(
             network.graph, pos=pos, ax=axis, nodelist=restrict_nodes,
-            node_size=nsize, node_color=node_color, node_shape=nshape,
-            linewidths=nborder_width, edge_color=ecolor,
+            edgelist=edges, node_size=nsize, node_color=node_color,
+            node_shape=nshape, linewidths=nborder_width, edge_color=ecolor,
             edge_cmap=palette_continuous(), cmap=ncmap,
             with_labels=show_labels, width=esize, edgecolors=nborder_color)
     elif nngt.get_config("backend") == "igraph":
@@ -868,7 +886,13 @@ def library_draw(network, nsize="total-degree", ncolor="group", nshape="o",
             "palette": palette,
         }
 
-        graph_artist = GraphArtist(network.graph, axis, **visual_style)
+        graph = network.graph
+
+        if restrict_edges is not None:
+            eids  = [network.edge_id(e) for e in restrict_edges]
+            graph = network.graph.subgraph_edges(eids, delete_vertices=False)
+
+        graph_artist = GraphArtist(graph, axis, **visual_style)
 
         axis.artists.append(graph_artist)
 
@@ -885,7 +909,7 @@ def _node_edge_shape_size(network, nshape, nsize, max_nsize, esize, max_esize,
                           simple_nodes=False):
     ''' Returns the shape and size of the nodes and edges '''
     n = network.node_nb() if restrict_nodes is None else len(restrict_nodes)
-    e = len(edges)
+    e = len(edges) if edges is not None else network.edge_nb()
 
     # markers
     markers = nshape
@@ -1008,7 +1032,7 @@ def _node_size(network, restrict_nodes, nsize):
 
 
 def _edge_size(network, edges, esize):
-    num_edges = len(edges)
+    num_edges = len(edges) if edges is not None else network.edge_nb()
 
     size = np.repeat(1., num_edges)
 

--- a/nngt/plot/plt_networks.py
+++ b/nngt/plot/plt_networks.py
@@ -224,7 +224,7 @@ def draw_network(network, nsize="total-degree", ncolor="group", nshape="o",
     if fast:
         simple_nodes = True
 
-    max_nsize = 20 if simple_nodes else 5
+    max_nsize = (20 if simple_nodes else 5) if max_nsize is None else max_nsize
 
     markers, nsize, esize = _node_edge_shape_size(
         network, nshape, nsize, max_nsize, esize, max_esize, restrict_nodes,
@@ -346,16 +346,19 @@ def draw_network(network, nsize="total-degree", ncolor="group", nshape="o",
                           else list(set(g.ids).intersection(restrict_nodes))
                     axis.scatter(pos[ids, 0], pos[ids, 1], c=c[ids],
                                  s=0.5*np.array(nsize)[ids],
-                                 marker=markers[ids[0]], zorder=2)
+                                 marker=markers[ids[0]], zorder=2,
+                                 mec=nborder_color, mew=nborder_width)
             else:
                 ids = range(network.node_nb()) if restrict_nodes is None \
                       else restrict_nodes
                 for i in ids:
                     axis.plot(pos[i, 0], pos[i, 1], c=c[i], ms=0.5*nsize[i],
-                              marker=markers[ids[0]], ls="", zorder=2)
+                              marker=markers[ids[0]], ls="", zorder=2,
+                              mec=nborder_color, mew=nborder_width)
         else:
             axis.scatter(pos[:, 0], pos[:, 1], c=c, s=0.5*np.array(nsize),
-                         marker=nshape, zorder=2)
+                         marker=nshape, zorder=2, edgecolor=nborder_color,
+                         linewidths=nborder_width)
     else:
         axis.set_aspect(1.)
 

--- a/nngt/plot/plt_networks.py
+++ b/nngt/plot/plt_networks.py
@@ -71,9 +71,9 @@ def draw_network(network, nsize="total-degree", ncolor="group", nshape="o",
                  threshold=0.5, decimate_connections=None, spatial=True,
                  restrict_sources=None, restrict_targets=None,
                  restrict_nodes=None, restrict_edges=None,
-                 show_environment=True, fast=False,
-                 size=(600, 600), xlims=None, ylims=None, dpi=75, axis=None,
-                 colorbar=False, layout=None, show=False, **kwargs):
+                 show_environment=True, fast=True, size=(600, 600), xlims=None,
+                 ylims=None, dpi=75, axis=None, colorbar=False, cb_label=None,
+                 layout=None, show=False, **kwargs):
     '''
     Draw a given graph/network.
 
@@ -141,6 +141,8 @@ def draw_network(network, nsize="total-degree", ncolor="group", nshape="o",
         Axis on which the network will be plotted.
     colorbar : bool, optional (default: False)
         Whether to display a colorbar for the node colors or not.
+    cb_label : str, optional (default: None)
+        A label for the colorbar.
     layout : str, optional (default: random or spatial positions)
         Name of a standard layout to structure the network. Available layouts
         are: "circular" or "random". If no layout is provided and the network
@@ -231,8 +233,8 @@ def draw_network(network, nsize="total-degree", ncolor="group", nshape="o",
         edges, size, threshold, simple_nodes=simple_nodes)
 
     # node color information
-    default_ncmap = (palette_discrete() if ncolor == "group"
-                     else palette_continuous())
+    default_ncmap = (palette_discrete() if not nonstring_container(ncolor) and
+                     ncolor == "group" else palette_continuous())
 
     ncmap = get_cmap(kwargs.get("node_cmap", default_ncmap))
     node_color, nticks, ntickslabels, nlabel = \
@@ -324,6 +326,9 @@ def draw_network(network, nsize="total-degree", ncolor="group", nshape="o",
                     cb.set_label(nlabel)
             else:
                 cb = plt.colorbar(sm, cax=cax, shrink=0.8)
+
+                if cb_label is not None:
+                    cb.ax.set_ylabel(cb_label)
         else:
             cmin, cmax = np.min(c), np.max(c)
             if cmin != cmax:

--- a/testing/test_plots.py
+++ b/testing/test_plots.py
@@ -112,6 +112,11 @@ def test_library_plot():
     nplt.library_draw(g, ncolor="in-degree", esize="weight", layout="circular",
                       show=False)
 
+    edges = g.edges_array[::5]
+
+    nplt.library_draw(g, ncolor="in-degree", esize="weight", layout="circular",
+                      restrict_edges=edges, show=False)
+
 
 if __name__ == "__main__":
     test_plot_config()


### PR DESCRIPTION
The edge list returned from the ``connect_*`` functions now return only the newly created edges so that they can be used efficiently with the new ``restrict_edges`` keyword in ``draw_network``.

``make_spatial`` now works properly when only positions are provided during graph initialization.

``draw_network``
* corrected restrict nodes
* improved fast plot (markers)
*add colorbar label