### PR TITLE
Fix copy

### DIFF
--- a/nngt/core/graph.py
+++ b/nngt/core/graph.py
@@ -515,6 +515,8 @@ class Graph(nngt.core.GraphObject):
         Returns a deepcopy of the current :class:`~nngt.Graph`
         instance
         '''
+        if nngt.get_config("mpi"):
+            raise NotImplementedError("`copy` is not MPI-safe yet.")
         gc_instance = Graph(name=self._name + '_copy',
                             weighted=self.is_weighted(), copy_graph=self,
                             directed=self.is_directed())

--- a/nngt/core/graph.py
+++ b/nngt/core/graph.py
@@ -433,14 +433,22 @@ class Graph(nngt.core.GraphObject):
                          directed=directed, weighted=weighted)
 
         # take care of the weights and delays
-        if weighted:
-            self.new_edge_attribute('weight', 'double')
-            self._w = _edge_prop(kwargs.get("weights", None))
-        if "delays" in kwargs:
-            self.new_edge_attribute('delay', 'double')
-            self._d = _edge_prop(kwargs.get("delays", None))
-        if 'inh_weight_factor' in kwargs:
-            self._iwf = kwargs['inh_weight_factor']
+        if copy_graph is None:
+            if weighted:
+                self.new_edge_attribute('weight', 'double')
+                self._w = _edge_prop(kwargs.get("weights", None))
+            if "delays" in kwargs:
+                self.new_edge_attribute('delay', 'double')
+                self._d = _edge_prop(kwargs.get("delays", None))
+            if 'inh_weight_factor' in kwargs:
+                self._iwf = kwargs['inh_weight_factor']
+        else:
+            self._w   = getattr(copy_graph, "_w", None)
+            self._d   = getattr(copy_graph, "_d", None)
+            self._iwf = getattr(copy_graph, "_iwf", None)
+
+            self._eattr._num_values_set = \
+                copy_graph._eattr._num_values_set.copy()
 
         # update the counters
         self.__class__.__num_graphs += 1
@@ -508,7 +516,8 @@ class Graph(nngt.core.GraphObject):
         instance
         '''
         gc_instance = Graph(name=self._name + '_copy',
-                            weighted=self.is_weighted(), copy_graph=self)
+                            weighted=self.is_weighted(), copy_graph=self,
+                            directed=self.is_directed())
 
         if self.is_spatial():
             nngt.SpatialGraph.make_spatial(

--- a/nngt/core/gt_graph.py
+++ b/nngt/core/gt_graph.py
@@ -336,6 +336,7 @@ class _GtGraph(GraphInterface):
                 g.set_directed(False)
                 remove_parallel_edges(g)
             elif directed and not g.is_directed():
+                g = g.copy()
                 g.set_directed(True)
 
             self._from_library_graph(g, copy=True)
@@ -701,18 +702,15 @@ class _GtGraph(GraphInterface):
         edges = graph.num_edges()
 
         if copy:
-            self._graph = nngt._config["graph"](g=graph, directed=True)
+            self._graph = nngt._config["graph"](g=graph)
         else:
             self._graph = graph
 
         # get attributes names and "types" and initialize them
         if nodes:
             for key, val in graph.vertex_properties.items():
-                try:
-                    super(type(self._nattr), self._nattr).__setitem__(
-                        key, _get_dtype(val.a[0]))
-                except:
-                    pass
+                super(type(self._nattr), self._nattr).__setitem__(
+                    key, _get_dtype(val.a[0]))
 
         if edges:
             for key, val in graph.edge_properties.items():

--- a/nngt/core/gt_graph.py
+++ b/nngt/core/gt_graph.py
@@ -709,8 +709,12 @@ class _GtGraph(GraphInterface):
         # get attributes names and "types" and initialize them
         if nodes:
             for key, val in graph.vertex_properties.items():
-                super(type(self._nattr), self._nattr).__setitem__(
-                    key, _get_dtype(val.a[0]))
+                try:
+                    super(type(self._nattr), self._nattr).__setitem__(
+                        key, _get_dtype(val.a[0]))
+                except TypeError:
+                    super(type(self._nattr), self._nattr).__setitem__(
+                        key, _get_dtype(val.get_2d_array([0])))
 
         if edges:
             for key, val in graph.edge_properties.items():

--- a/nngt/core/nx_graph.py
+++ b/nngt/core/nx_graph.py
@@ -748,6 +748,7 @@ class _NxGraph(GraphInterface):
 
         if num_edges:
             e0 = next(iter(graph.edges))
+
             for key, val in graph.edges[e0].items():
                 super(type(self._eattr), self._eattr).__setitem__(
                     key, _get_dtype(val))

--- a/testing/test_basics.py
+++ b/testing/test_basics.py
@@ -287,6 +287,7 @@ def test_new_node_attr():
             g.name, *g.get_positions(n))
 
 
+@pytest.mark.mpi_skip
 def test_graph_copy():
     '''
     Test partial and full graph copy.


### PR DESCRIPTION
* Corrects initialization of edge attributes upon graph copy.
* Solves issue with graph-tool where, in the case of undirected graphs, both the original and the copied graph would be set to directed, only the copied graph for other backends.
* Forbid use of copy with MPI.

Fixes #97