### PR TITLE
Fix get_edges for undirected graphs

### DIFF
--- a/nngt/core/graph.py
+++ b/nngt/core/graph.py
@@ -781,6 +781,10 @@ class Graph(nngt.core.GraphObject):
             # (note that this has no significant speed impact)
             mat = self.adjacency_matrix()
 
+            if not self.is_directed():
+                from scipy.sparse import tril
+                mat = tril(mat, format="csr")
+
             if source_node is None:
                 source_node = np.array(
                     [i for i in range(self.node_nb())], dtype=int)

--- a/nngt/core/graph.py
+++ b/nngt/core/graph.py
@@ -38,7 +38,7 @@ from nngt.io.graph_loading import _load_from_file, _library_load
 from nngt.io.io_helpers import _get_format
 from nngt.io.graph_saving import _as_string
 from nngt.lib import InvalidArgument, nonstring_container
-from nngt.lib.connect_tools import _set_degree_type
+from nngt.lib.connect_tools import _set_degree_type, _unique_rows
 from nngt.lib.graph_helpers import _edge_prop
 from nngt.lib.logger import _log_message
 from nngt.lib.test_functions import graph_tool_check, deprecated, is_integer
@@ -779,52 +779,35 @@ class Graph(nngt.core.GraphObject):
             # then use the list of nodes to get the original ids back
             # to do that we first convert source/target_node to lists
             # (note that this has no significant speed impact)
-            nnz = None
+            src, tgt = None, None
 
             if source_node is None:
-                source_node = np.array(
+                src = np.array(
                     [i for i in range(self.node_nb())], dtype=int)
             elif is_integer(source_node):
-                source_node = np.array([source_node], dtype=int)
+                src = np.array([source_node], dtype=int)
             else:
-                source_node = np.sort(source_node)
+                src = np.sort(source_node)
 
             if target_node is None:
-                target_node = np.array(
+                tgt = np.array(
                     [i for i in range(self.node_nb())], dtype=int)
             elif is_integer(target_node):
-                target_node = np.array([target_node], dtype=int)
+                tgt = np.array([target_node], dtype=int)
             else:
-                target_node = np.sort(target_node)
+                tgt = np.sort(target_node)
 
-            # check graph directedness
-            if self.is_directed():
-                mat = self.adjacency_matrix()
+            mat = self.adjacency_matrix()
 
-                nnz = mat[source_node].tocsc()[:, target_node].nonzero()
-            else:
-                from scipy.sparse import triu
+            nnz = mat[src].tocsc()[:, tgt].nonzero()
 
-                mat = triu(self.adjacency_matrix(), format="csr")
+            edges = np.array([src[nnz[0]], tgt[nnz[1]]], dtype=int).T
 
-                nodes = set()
+            # remove reciprocal if graph is undirected
+            if not self.is_directed():
+                edges.sort()
 
-                if is_integer(source_node):
-                    nodes.add(source_node)
-                elif source_node is not None:
-                    nodes.update(source_node)
-
-                if is_integer(target_node):
-                    nodes.add(target_node)
-                elif target_node is not None:
-                    nodes.update(target_node)
-
-                nnz = mat[list(nodes)].nonzero()
-
-            print(nnz)
-
-            edges = np.array(
-                [source_node[nnz[0]], target_node[nnz[1]]], dtype=int).T
+                edges = _unique_rows(edges)
 
         # check attributes
         if attribute is None:

--- a/testing/test_basics.py
+++ b/testing/test_basics.py
@@ -569,6 +569,39 @@ def test_undirected_adjacency():
         g.adjacency_matrix(types=True, weights=True).todense(), wt_mat))
 
 
+@pytest.mark.mpi_skip
+def test_get_edges():
+    ''' Check that correct edges are returned '''
+    # directed
+    g = nngt.Graph(4, directed=True)
+
+    edges = [(0, 1), (1, 0), (1, 2), (2, 3)]
+
+    g.new_edges(edges)
+
+    assert np.array_equal(g.get_edges(source_node=[0, 1]), edges[:3])
+    assert np.array_equal(g.get_edges(target_node=[0, 1]), edges[:2])
+    assert np.array_equal(g.get_edges(source_node=[0, 2], target_node=[0, 1]),
+                          [(0, 1)])
+
+    # undirected
+    g = nngt.Graph(4, directed=False)
+
+    edges = [(0, 1), (1, 2), (2, 3)]
+
+    g.new_edges(edges)
+    
+    res = [(0, 1), (1, 2)]
+
+    assert np.array_equal(g.get_edges(source_node=[0, 1]), res)
+    assert np.array_equal(g.get_edges(target_node=[0, 1]), res)
+    assert np.array_equal(g.get_edges(source_node=[0, 2], target_node=[0, 1]),
+                          res)
+
+    assert np.array_equal(g.get_edges(source_node=0, target_node=1), [(0, 1)])
+    assert np.array_equal(g.get_edges(source_node=0, target_node=[0, 1]),
+                          [(0, 1)])
+
 # ---------- #
 # Test suite #
 # ---------- #
@@ -580,6 +613,7 @@ if __name__ == "__main__":
     test_new_node_attr()
     test_graph_copy()
     test_degrees_neighbors()
+    test_get_edges()
 
     if not nngt.get_config('mpi'):
         test_node_creation()


### PR DESCRIPTION
Fixes #101 so that ``get_edges`` returns the correct edges when ``source_node`` and ``target_node`` are used.