### PR TITLE
Bugfix: correct graph loading with 0-out-degree neighbour lines

### DIFF
--- a/nngt/io/graph_saving.py
+++ b/nngt/io/graph_saving.py
@@ -38,7 +38,7 @@ from nngt.lib.logger import _log_message
 from ..geometry import Shape, _shapely_support
 from .io_helpers import _get_format
 from .saving_helpers import (_neighbour_list, _edge_list, _gml, _custom_info,
-                           _gml_info)
+                           _gml_info, _str_bytes_len)
 
 
 logger = logging.getLogger(__name__)

--- a/nngt/io/loading_helpers.py
+++ b/nngt/io/loading_helpers.py
@@ -202,22 +202,24 @@ def _get_edges_neighbour(lst_lines, attributes, ignore, notifier, separator,
 
         if line and not (line.startswith(notifier) or line.startswith(ignore)):
             len_first_delim = line.find(separator)
-            source = int(line[:len_first_delim])
-            len_first_delim += 1
 
-            if len_first_delim:
-                neighbours = line[len_first_delim:].split(separator)
+            if len_first_delim > 0:
+                source = int(line[:len_first_delim])
+                len_first_delim += 1
 
-                for stub in neighbours:
-                    content = stub.split(secondary)
-                    target = int(content[0])
+                if len_first_delim:
+                    neighbours = line[len_first_delim:].split(separator)
 
-                    edges.append((source, target))
+                    for stub in neighbours:
+                        content = stub.split(secondary)
+                        target = int(content[0])
 
-                    attr_val = content[1:] if len(content) > 1 else []
+                        edges.append((source, target))
 
-                    for name, val in zip(attributes, attr_val):
-                        di_attributes[name].append(di_convert[name](val))
+                        attr_val = content[1:] if len(content) > 1 else []
+
+                        for name, val in zip(attributes, attr_val):
+                            di_attributes[name].append(di_convert[name](val))
 
     return edges
 

--- a/testing/test_io.py
+++ b/testing/test_io.py
@@ -170,6 +170,56 @@ class TestIO(TestBasis):
             self.assertTrue(allclose)
 
 
+def test_empty_out_degree():
+    g = nngt.Graph(2)
+
+    g.new_edge(0, 1)
+
+    for fmt in ("neighbour", "edge_list"):
+        nngt.save_to_file(g, current_dir + "g.graph", fmt=fmt)
+
+        h = nngt.load_from_file(current_dir + "g.graph", fmt=fmt)
+
+        assert np.array_equal(g.edges_array, h.edges_array)
+
+    try:
+        os.remove(current_dir + 'g.graph')
+    except:
+        pass
+
+
+def test_str_attributes():
+    g = nngt.Graph(2)
+
+    g.new_edge(0, 1)
+
+    g.new_edge_attribute("type", "str")
+    g.set_edge_attribute("type", val='odd')
+
+    g.new_node_attribute("rnd", "str")
+    g.set_node_attribute("rnd", values=["sadf", "sdfr"])
+
+    for fmt in ("neighbour", "edge_list"):
+        nngt.save_to_file(g, current_dir + "g.graph", fmt=fmt)
+
+        h = nngt.load_from_file(current_dir + "g.graph", fmt=fmt)
+
+        assert np.array_equal(g.edges_array, h.edges_array)
+
+
+        print(h.edge_attributes["type"])
+        assert np.array_equal(g.edge_attributes["type"],
+                              h.edge_attributes["type"])
+
+        assert np.array_equal(g.node_attributes["rnd"],
+                              h.node_attributes["rnd"])
+
+    try:
+        os.remove(current_dir + 'g.graph')
+    except:
+        pass
+
+
 # ---------- #
 # Test suite #
 # ---------- #
@@ -178,3 +228,5 @@ suite = unittest.TestLoader().loadTestsFromTestCase(TestIO)
 
 if __name__ == "__main__":
     unittest.main()
+    test_empty_out_degree()
+    test_str_attributes()

--- a/testing/test_io.py
+++ b/testing/test_io.py
@@ -193,10 +193,10 @@ def test_str_attributes():
 
     g.new_edge(0, 1)
 
-    g.new_edge_attribute("type", "str")
+    g.new_edge_attribute("type", "string")
     g.set_edge_attribute("type", val='odd')
 
-    g.new_node_attribute("rnd", "str")
+    g.new_node_attribute("rnd", "string")
     g.set_node_attribute("rnd", values=["sadf", "sdfr"])
 
     for fmt in ("neighbour", "edge_list"):
@@ -206,8 +206,6 @@ def test_str_attributes():
 
         assert np.array_equal(g.edges_array, h.edges_array)
 
-
-        print(h.edge_attributes["type"])
         assert np.array_equal(g.edge_attributes["type"],
                               h.edge_attributes["type"])
 
@@ -227,6 +225,6 @@ def test_str_attributes():
 suite = unittest.TestLoader().loadTestsFromTestCase(TestIO)
 
 if __name__ == "__main__":
-    unittest.main()
-    test_empty_out_degree()
+    # ~ unittest.main()
+    # ~ test_empty_out_degree()
     test_str_attributes()

--- a/testing/test_io.py
+++ b/testing/test_io.py
@@ -225,6 +225,6 @@ def test_str_attributes():
 suite = unittest.TestLoader().loadTestsFromTestCase(TestIO)
 
 if __name__ == "__main__":
-    # ~ unittest.main()
-    # ~ test_empty_out_degree()
+    unittest.main()
+    test_empty_out_degree()
     test_str_attributes()

--- a/testing/test_io.py
+++ b/testing/test_io.py
@@ -15,6 +15,7 @@ import os
 import unittest
 
 import numpy as np
+import pytest
 
 import nngt
 from nngt.lib.test_functions import _old_graph_tool
@@ -169,7 +170,7 @@ class TestIO(TestBasis):
 
             self.assertTrue(allclose)
 
-
+@pytest.mark.mpi_skip
 def test_empty_out_degree():
     g = nngt.Graph(2)
 
@@ -188,6 +189,7 @@ def test_empty_out_degree():
         pass
 
 
+@pytest.mark.mpi_skip
 def test_str_attributes():
     g = nngt.Graph(2)
 


### PR DESCRIPTION
This PR fixes #117 so that graphs have nodes with zero out-degree are loading correctly in the "neighbour" format.