### PR TITLE
Bugfix: correct global clustering for unweighted directed networks

### DIFF
--- a/nngt/analysis/clustering.py
+++ b/nngt/analysis/clustering.py
@@ -115,6 +115,9 @@ def global_clustering(g, directed=True, weights=None, method="continuous",
     :func:`~nngt.analysis.triplet_count`
     :func:`~nngt.analysis.triangle_count`
     '''
+    assert method in ("barrat", "continuous", "onnela"), \
+        "Unknown method '{}'".format(method)
+
     # check directivity and weights
     directed *= g.is_directed()
     weighted  = weights not in (False, None)
@@ -123,8 +126,8 @@ def global_clustering(g, directed=True, weights=None, method="continuous",
         return global_clustering_binary_undirected(g)
     elif not weighted:
         # directed clustering
-        triangles = triangle_count(g)
-        triplets  = triplet_count(g)
+        triangles = triangle_count(g, mode=mode)
+        triplets  = triplet_count(g, mode=mode)
 
         return np.sum(triangles) / np.sum(triplets)
 

--- a/testing/test_analysis.py
+++ b/testing/test_analysis.py
@@ -395,12 +395,10 @@ def test_partial_directed_clustering():
 
     for m in ("continuous", "barrat", "onnela"):
         assert np.array_equal(
-            nngt.analysis.local_clustering(g, mode="cycle", method=m),
-            [1, 1, 1])
+            na.local_clustering(g, mode="cycle", method=m), [1, 1, 1])
 
         assert np.array_equal(
-            nngt.analysis.local_clustering(g, mode="cycle", method=m,
-                                           weights="weight"),
+            na.local_clustering(g, mode="cycle", method=m, weights="weight"),
             [1, 1, 1])
 
     # middleman, fan-in, fan-out
@@ -414,39 +412,32 @@ def test_partial_directed_clustering():
 
     for m in ("continuous", "barrat", "onnela"):
         assert np.array_equal(
-            nngt.analysis.local_clustering(g, mode="cycle", method=m),
+            na.local_clustering(g, mode="cycle", method=m), [0, 0, 0])
+
+        assert np.array_equal(
+            na.local_clustering(g, mode="cycle", method=m, weights="weight"),
             [0, 0, 0])
 
         assert np.array_equal(
-            nngt.analysis.local_clustering(g, mode="cycle", method=m,
-                                           weights="weight"),
-            [0, 0, 0])
+            na.local_clustering(g, mode="middleman", method=m), [0, 1, 0])
 
         assert np.array_equal(
-            nngt.analysis.local_clustering(g, mode="middleman", method=m),
+            na.local_clustering(g, mode="middleman", method=m,
+                                weights="weight"),
             [0, 1, 0])
 
         assert np.array_equal(
-            nngt.analysis.local_clustering(g, mode="middleman", method=m,
-                                           weights="weight"),
-            [0, 1, 0])
+            na.local_clustering(g, mode="fan-in", method=m), [0, 0, 0.5])
 
         assert np.array_equal(
-            nngt.analysis.local_clustering(g, mode="fan-in", method=m),
+            na.local_clustering(g, mode="fan-in", method=m, weights="weight"),
             [0, 0, 0.5])
 
         assert np.array_equal(
-            nngt.analysis.local_clustering(g, mode="fan-in", method=m,
-                                           weights="weight"),
-            [0, 0, 0.5])
+            na.local_clustering(g, mode="fan-out", method=m), [0.5, 0, 0])
 
         assert np.array_equal(
-            nngt.analysis.local_clustering(g, mode="fan-out", method=m),
-            [0.5, 0, 0])
-
-        assert np.array_equal(
-            nngt.analysis.local_clustering(g, mode="fan-out", method=m,
-                                           weights="weight"),
+            na.local_clustering(g, mode="fan-out", method=m, weights="weight"),
             [0.5, 0, 0])
 
     # complex graph
@@ -456,78 +447,94 @@ def test_partial_directed_clustering():
 
     for m in ("continuous", "barrat", "onnela"):
         assert np.array_equal(
-            nngt.analysis.local_clustering(g, mode="cycle", method=m),
-            [0, 0.5, 1, 0.5])
+            na.local_clustering(g, mode="cycle", method=m), [0, 0.5, 1, 0.5])
 
         assert np.array_equal(
-            nngt.analysis.local_clustering(g, mode="middleman", method=m),
-            [1, 0, 0, 0.5])
+            na.local_clustering(g, mode="middleman", method=m), [1, 0, 0, 0.5])
 
         assert np.array_equal(
-            nngt.analysis.local_clustering(g, mode="fan-in", method=m),
-            [0, 0, 0.5, 0.5])
+            na.local_clustering(g, mode="fan-in", method=m), [0, 0, 0.5, 0.5])
 
         assert np.array_equal(
-            nngt.analysis.local_clustering(g, mode="fan-out", method=m),
-            [0, 1/3, 0, 0])
+            na.local_clustering(g, mode="fan-out", method=m), [0, 1/3, 0, 0])
 
     # weighted (barrat)
     g.set_weights([1, 0.5, 0.4, 1, 0.6, 1])
 
     assert np.all(np.isclose(
-        nngt.analysis.local_clustering(g, mode="fan-out", weights="weight",
-                                       method="barrat"), [0, 1.45/3.8, 0, 0]))
+        na.local_clustering(g, mode="fan-out", weights="weight",
+                            method="barrat"),
+        [0, 1.45/3.8, 0, 0]))
 
     assert np.array_equal(
-        nngt.analysis.local_clustering(g, mode="fan-in", weights="weight",
-                                       method="barrat"), [0, 0, 0.5, 0.5])
+        na.local_clustering(g, mode="fan-in", weights="weight",
+                            method="barrat"), [0, 0, 0.5, 0.5])
 
     assert np.all(np.isclose(
-        nngt.analysis.local_clustering(
-            g, mode="cycle", weights="weight", method="barrat"),
+        na.local_clustering(g, mode="cycle", weights="weight", method="barrat"),
         [0, 0.8/1.35, 1, 0.5]))
 
     assert np.array_equal(
-        nngt.analysis.local_clustering(g, mode="middleman", weights="weight",
-                                       method="barrat"), [1, 0, 0, 0.5])
+        na.local_clustering(g, mode="middleman", weights="weight",
+                            method="barrat"), [1, 0, 0, 0.5])
 
     # weighted (onnela)
     g.set_weights([1, 1/8, 1, 1, 1, 1/8])
 
     assert np.array_equal(
-        nngt.analysis.local_clustering(g, mode="middleman", weights="weight",
-                                       method="onnela"), [0.5, 0, 0, 0.25])
+        na.local_clustering(g, mode="middleman", weights="weight",
+                            method="onnela"), [0.5, 0, 0, 0.25])
 
     assert np.array_equal(
-        nngt.analysis.local_clustering(g, mode="cycle", weights="weight",
-                                       method="onnela"), [0, 0.25, 0.5, 0.25])
+        na.local_clustering(g, mode="cycle", weights="weight", method="onnela"),
+        [0, 0.25, 0.5, 0.25])
 
     assert np.all(np.isclose(
-        nngt.analysis.local_clustering(g, mode="fan-out", weights="weight",
-                                       method="onnela"), [0, 1/6, 0, 0]))
+        na.local_clustering(g, mode="fan-out", weights="weight",
+                            method="onnela"), [0, 1/6, 0, 0]))
 
     assert np.array_equal(
-        nngt.analysis.local_clustering(g, mode="fan-in", weights="weight",
-                                       method="onnela"), [0, 0, 0.25, 0.25])
+        na.local_clustering(g, mode="fan-in", weights="weight",
+                            method="onnela"), [0, 0, 0.25, 0.25])
 
     # weighted (continuous)
     g.set_weights([1, 1/64, 1/64, 1, 1, 1])
 
     assert np.all(np.isclose(
-        nngt.analysis.local_clustering(g, mode="fan-out", weights="weight"),
+        na.local_clustering(g, mode="fan-out", weights="weight"),
         [0, 4/17, 0, 0]))
 
     assert np.all(np.isclose(
-        nngt.analysis.local_clustering(g, mode="fan-in", weights="weight"),
+        na.local_clustering(g, mode="fan-in", weights="weight"),
         [0, 0, 0.25, 1/32]))
 
     assert np.all(np.isclose(
-        nngt.analysis.local_clustering(g, mode="cycle", weights="weight"),
+        na.local_clustering(g, mode="cycle", weights="weight"),
         [0, 8/9, 1, 0.5]))
 
     assert np.all(np.isclose(
-        nngt.analysis.local_clustering(g, mode="middleman", weights="weight"),
+        na.local_clustering(g, mode="middleman", weights="weight"),
         [0.5, 0, 0, 1/32]))
+
+
+@pytest.mark.mpi_skip
+def test_global_clustering():
+    num_nodes = 3
+
+    g = nngt.Graph(num_nodes)
+    g.new_edges([(0, 1), (0, 2), (2, 1)])
+
+    with pytest.raises(AssertionError):
+        na.global_clustering(g, method='plop')
+
+    modes   = ('total', 'cycle', 'middleman', 'fan-in', 'fan-out')
+    results = (0.5, 0, 1, 0.5, 0.5)
+
+    for m in methods:
+        for mode, res in zip(modes, results):
+            gc = na.global_clustering(g, method=m, mode=mode)
+
+            assert gc == res
 
 
 @pytest.mark.mpi_skip
@@ -633,12 +640,13 @@ def test_swp():
 
 if __name__ == "__main__":
     if not nngt.get_config("mpi"):
-        test_binary_undirected_clustering()
-        test_weighted_undirected_clustering()
-        test_weighted_directed_clustering()
-        test_reciprocity()
-        test_iedges()
-        test_swp()
-        test_partial_directed_clustering()
-        nngt.use_backend("nngt")
-        test_clustering_parameters()
+        # ~ test_binary_undirected_clustering()
+        # ~ test_weighted_undirected_clustering()
+        # ~ test_weighted_directed_clustering()
+        # ~ test_reciprocity()
+        # ~ test_iedges()
+        # ~ test_swp()
+        # ~ test_partial_directed_clustering()
+        # ~ test_clustering_parameters()
+
+        test_global_clustering()

--- a/testing/test_basics.py
+++ b/testing/test_basics.py
@@ -653,8 +653,6 @@ def test_delete():
     g.delete_nodes([0])
     adj = g.adjacency_matrix(weights=True, mformat="dense")
 
-    # ~ print(adj)
-    # ~ print(mat[1:, 1:])
     assert np.array_equal(adj, mat[1:, 1:])
 
     assert np.array_equal(g.node_attributes["test"], [1, 2, 3, 4, 5])
@@ -686,5 +684,4 @@ if __name__ == "__main__":
         test_node_creation()
         test_edge_creation()
         test_has_edges_edge_id()
-        nngt.use_backend("graph-tool")
         test_delete()


### PR DESCRIPTION
This PR corrects an error with global clustering for directed unweighted networks where it was always returning the total clustering