### PR TITLE
Fix eid issue when copying graphs

### DIFF
--- a/nngt/core/gt_graph.py
+++ b/nngt/core/gt_graph.py
@@ -876,15 +876,16 @@ class _GtGraph(GraphInterface):
 
         if edges:
             for key, val in graph.edge_properties.items():
-                if val.value_type() == 'string':
-                    super(type(self._eattr), self._eattr).__setitem__(
-                        key, 'string')
-                elif val.value_type().startswith('vector'):
-                    super(type(self._eattr), self._eattr).__setitem__(
-                        key, 'object')
-                else:
-                    super(type(self._eattr), self._eattr).__setitem__(
-                        key, _get_dtype(val.a[0]))
+                if key != 'eid':
+                    if val.value_type() == 'string':
+                        super(type(self._eattr), self._eattr).__setitem__(
+                            key, 'string')
+                    elif val.value_type().startswith('vector'):
+                        super(type(self._eattr), self._eattr).__setitem__(
+                            key, 'object')
+                    else:
+                        super(type(self._eattr), self._eattr).__setitem__(
+                            key, _get_dtype(val.a[0]))
 
         # make edge ids
         eids = self._graph.new_edge_property(

--- a/nngt/core/ig_graph.py
+++ b/nngt/core/ig_graph.py
@@ -651,8 +651,9 @@ class _IGraph(GraphInterface):
 
         if edges:
             for key, val in graph.es[0].attributes().items():
-                super(type(self._eattr), self._eattr).__setitem__(
-                    key, _get_dtype(val))
+                if key != 'eid':
+                    super(type(self._eattr), self._eattr).__setitem__(
+                        key, _get_dtype(val))
 
 
 def _get_weights(g, weights):

--- a/nngt/core/nx_graph.py
+++ b/nngt/core/nx_graph.py
@@ -852,8 +852,9 @@ class _NxGraph(GraphInterface):
             e0 = next(iter(graph.edges))
 
             for key, val in graph.edges[e0].items():
-                super(type(self._eattr), self._eattr).__setitem__(
-                    key, _get_dtype(val))
+                if key != "eid":
+                    super(type(self._eattr), self._eattr).__setitem__(
+                        key, _get_dtype(val))
 
 
 # tool function to generate the edges_array

--- a/testing/test_basics.py
+++ b/testing/test_basics.py
@@ -367,6 +367,9 @@ def test_graph_copy():
 
     assert g.is_directed() == h.is_directed() == False
 
+    # eid is protected and should not be copied to a visible edge attribute
+    assert "eid" not in h.edge_attributes
+
 
 def test_degrees_neighbors():
     '''


### PR DESCRIPTION
This PR fixes an issue with "eid" being copied as a normal (rather than protected) edge attribute using ``Graph.copy`` with all backends except nngt.