### PR TITLE
Fix and improve connect_* functions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,8 @@ doc/.build/
 doc/_build/
 doc/examples/sp_graph
 doc/examples/.ipynb_checkpoints/
+doc/gallery/graph_properties/
+doc/gallery/graph_structure/
 
 # generated rst
 doc/modules/examples

--- a/nngt/generation/cconnect.pyx
+++ b/nngt/generation/cconnect.pyx
@@ -191,7 +191,7 @@ def _all_to_all(cnp.ndarray[size_t, ndim=1] source_ids,
 def _total_degree_list(cnp.ndarray[int64, ndim=1] source_ids,
                        cnp.ndarray[int64, ndim=1] target_ids,
                        cnp.ndarray[int64, ndim=1] degree_list,
-                       bool directed=True, bool multigraph=False):
+                       bool directed=True, bool multigraph=False, **kwargs):
     ''' Called from _from_degree_list '''
     cdef:
         size_t num_source = len(source_ids)

--- a/nngt/generation/connect_algorithms.py
+++ b/nngt/generation/connect_algorithms.py
@@ -111,7 +111,7 @@ def _all_to_all(source_ids, target_ids, directed=True, multigraph=False,
 
 
 def _total_degree_list(source_ids, target_ids, degree_list, directed=True,
-                       multigraph=False):
+                       multigraph=False, **kwargs):
     ''' Called from _from_degree_list '''
     degree_list = np.array(degree_list, dtype=int)
 
@@ -532,7 +532,8 @@ def _erdos_renyi(source_ids, target_ids, density=None, edges=None,
     return ia_edges
 
 
-def _price_scale_free(ids, m, c, gamma, reciprocity, directed, multigraph):
+def _price_scale_free(ids, m, c, gamma, reciprocity, directed, multigraph,
+                      **kwargs):
     '''
     Generate a Price network.
     '''
@@ -595,8 +596,8 @@ def _price_scale_free(ids, m, c, gamma, reciprocity, directed, multigraph):
     return edges
 
 
-def _circular(source_ids, target_ids, coord_nb, reciprocity, directed,
-              reciprocity_choice="random"):
+def _circular(source_ids, target_ids, coord_nb, reciprocity=1, directed=True,
+              reciprocity_choice="random", **kwargs):
     '''
     Circular graph.
 
@@ -625,7 +626,7 @@ def _circular(source_ids, target_ids, coord_nb, reciprocity, directed,
 
 
 def _circular_directed_recip(node_ids, coord_nb, reciprocity,
-                             reciprocity_choice="random"):
+                             reciprocity_choice="random", **kwargs):
     ''' Circular graph with given reciprocity '''
     nodes    = len(node_ids)
     edges    = int(0.5*nodes*coord_nb*(1 + reciprocity))
@@ -698,7 +699,7 @@ def _circular_directed_recip(node_ids, coord_nb, reciprocity,
     return np.array([sources, targets], dtype=int).T
 
 
-def _circular_full(node_ids, coord_nb, directed):
+def _circular_full(node_ids, coord_nb, directed, **kwargs):
     ''' Create a circular graph with all possible edges '''
     nodes = len(node_ids)
 

--- a/nngt/generation/connect_algorithms.py
+++ b/nngt/generation/connect_algorithms.py
@@ -96,7 +96,7 @@ def _all_to_all(source_ids, target_ids, directed=True, multigraph=False,
                 edges[current_edges:next_enum, 1] = target_ids
                 current_edges = next_enum
     else:
-        edges       = np.empty((num_edges, 2))
+        edges       = np.empty((num_edges, 2), dtype=int)
         edges[:, 0] = np.repeat(source_ids, num_targets)
         edges[:, 1] = np.tile(target_ids, num_sources)
 

--- a/nngt/generation/connectors.py
+++ b/nngt/generation/connectors.py
@@ -27,6 +27,7 @@ import nngt
 from nngt.generation import graph_connectivity as gc
 from nngt.lib import is_iterable, nonstring_container
 from nngt.lib.test_functions import deprecated
+from nngt.lib.rng_tools import _generate_random
 
 
 __all__ = [
@@ -118,9 +119,19 @@ def connect_nodes(network, sources, targets, graph_model, density=None,
     attr = {}
 
     if 'weights' in kwargs:
-        attr['weight'] = kwargs['weights']
+        ww = kwargs['weights']
+
+        if isinstance(ww, dict):
+            attr['weight'] = _generate_random(len(elist), ww)
+        else:
+            attr['weight'] = ww
     if 'delays' in kwargs:
-        attr['delay'] = kwargs['delays']
+        dd = kwargs['delays']
+
+        if isinstance(ww, dict):
+            attr['delay'] = _generate_random(len(elist), dd)
+        else:
+            attr['delay'] = dd
     if network.is_spatial() and distance:
         attr['distance'] = distance
 

--- a/nngt/generation/graph_connectivity.py
+++ b/nngt/generation/graph_connectivity.py
@@ -37,14 +37,14 @@ from nngt.lib.test_functions import (mpi_checker, mpi_random, deprecated,
 __all__ = [
     'all_to_all',
     'circular',
-	'distance_rule',
-	'erdos_renyi',
+    'distance_rule',
+    'erdos_renyi',
     'fixed_degree',
     'from_degree_list',
     'gaussian_degree',
-	'newman_watts',
-	'random_scale_free',
-	'price_scale_free',
+    'newman_watts',
+    'random_scale_free',
+    'price_scale_free',
     'watts_strogatz',
 ]
 
@@ -149,7 +149,7 @@ def all_to_all(nodes=0, weighted=True, directed=True, multigraph=False,
 
     Note
     ----
-	`nodes` is required unless `population` is provided.
+    `nodes` is required unless `population` is provided.
 
     Returns
     -------
@@ -269,7 +269,7 @@ def fixed_degree(degree, degree_type='in', nodes=0, reciprocity=-1.,
         The type of the fixed degree, among ``'in'``, ``'out'`` or ``'total'``.
 
         @todo
-			`'total'` not implemented yet.
+            `'total'` not implemented yet.
 
     nodes : int, optional (default: None)
         The number of nodes in the graph.
@@ -299,9 +299,9 @@ def fixed_degree(degree, degree_type='in', nodes=0, reciprocity=-1.,
 
     Note
     ----
-	`nodes` is required unless `from_graph` or `population` is provided.
-	If an `from_graph` is provided, all preexistant edges in the
-	object will be deleted before the new connectivity is implemented.
+    `nodes` is required unless `from_graph` or `population` is provided.
+    If an `from_graph` is provided, all preexistant edges in the
+    object will be deleted before the new connectivity is implemented.
 
     Returns
     -------
@@ -352,7 +352,7 @@ def gaussian_degree(avg, std, degree_type='in', nodes=0, reciprocity=-1.,
     avg : float
         The value of the average degree.
     std : float
-		The standard deviation of the Gaussian distribution.
+        The standard deviation of the Gaussian distribution.
     degree_type : str, optional (default: 'in')
         The type of the fixed degree, among 'in', 'out' or 'total' (or the
         full version: 'in-degree'...)
@@ -390,9 +390,9 @@ def gaussian_degree(avg, std, degree_type='in', nodes=0, reciprocity=-1.,
 
     Note
     ----
-	`nodes` is required unless `from_graph` or `population` is provided.
-	If an `from_graph` is provided, all preexistant edges in the object
-	will be deleted before the new connectivity is implemented.
+    `nodes` is required unless `from_graph` or `population` is provided.
+    If an `from_graph` is provided, all preexistant edges in the object
+    will be deleted before the new connectivity is implemented.
     """
     # set node number and library graph
     graph_gd = from_graph
@@ -477,9 +477,9 @@ def erdos_renyi(density=None, nodes=0, edges=None, avg_deg=None,
 
     Note
     ----
-	`nodes` is required unless `from_graph` or `population` is provided.
-	If an `from_graph` is provided, all preexistant edges in the
-	object will be deleted before the new connectivity is implemented.
+    `nodes` is required unless `from_graph` or `population` is provided.
+    If an `from_graph` is provided, all preexistant edges in the
+    object will be deleted before the new connectivity is implemented.
     """
     # set node number and library graph
     graph_er = from_graph
@@ -563,11 +563,11 @@ def random_scale_free(in_exp, out_exp, nodes=0, density=None, edges=None,
 
     Note
     ----
-	As reciprocity increases, requested values of `in_exp` and `out_exp`
-	will be less and less respected as the distribution will converge to a
-	common exponent :math:`\gamma = (\gamma_i + \gamma_o) / 2`.
-	Parameter `nodes` is required unless `from_graph` or `population` is
-	provided.
+    As reciprocity increases, requested values of `in_exp` and `out_exp`
+    will be less and less respected as the distribution will converge to a
+    common exponent :math:`\gamma = (\gamma_i + \gamma_o) / 2`.
+    Parameter `nodes` is required unless `from_graph` or `population` is
+    provided.
     """
     # set node number and library graph
     graph_rsf = from_graph
@@ -858,7 +858,7 @@ def newman_watts(coord_nb, proba_shortcut=None, reciprocity_circular=1.,
 
     Note
     ----
-	`nodes` is required unless `from_graph` or `population` is provided.
+    `nodes` is required unless `from_graph` or `population` is provided.
     """
     if multigraph:
         raise ValueError("`multigraph` is not supported for Watts-Strogatz.")
@@ -954,7 +954,7 @@ def watts_strogatz(coord_nb, proba_shortcut=None, reciprocity_circular=1.,
 
     Note
     ----
-	`nodes` is required unless `from_graph` or `population` is provided.
+    `nodes` is required unless `from_graph` or `population` is provided.
     """
     if multigraph:
         raise ValueError("`multigraph` is not supported for Newman-Watts.")

--- a/nngt/generation/graph_connectivity.py
+++ b/nngt/generation/graph_connectivity.py
@@ -34,6 +34,21 @@ from nngt.lib.test_functions import (mpi_checker, mpi_random, deprecated,
                                      on_master_process)
 
 
+__all__ = [
+    'all_to_all',
+    'circular',
+	'distance_rule',
+	'erdos_renyi',
+    'fixed_degree',
+    'from_degree_list',
+    'gaussian_degree',
+	'newman_watts',
+	'random_scale_free',
+	'price_scale_free',
+    'watts_strogatz',
+]
+
+
 # do default import
 
 from .connect_algorithms import *
@@ -94,21 +109,6 @@ if nngt.get_config("mpi"):
     except ImportError as e:
         nngt._config['mpi'] = False
         raise e
-
-
-__all__ = [
-    'all_to_all',
-    'circular',
-	'distance_rule',
-	'erdos_renyi',
-    'fixed_degree',
-    'from_degree_list',
-    'gaussian_degree',
-	'newman_watts',
-	'random_scale_free',
-	'price_scale_free',
-    'watts_strogatz',
-]
 
 
 # ----------------------------- #

--- a/nngt/lib/nngt_config.py
+++ b/nngt/lib/nngt_config.py
@@ -388,10 +388,9 @@ def _post_update_parallelism(new_config, old_gl, old_msd, old_mt, old_mpi):
 
     # reload for mpi
     if new_config.get('mpi', old_mpi) != old_mpi:
-        # connectors.py and rewiring.py use directly
-        # nngt.generation.graph_connectivity so they always access the reloaded
-        # version and we don't need to reload them
         reload(sys.modules["nngt"].generation.graph_connectivity)
+        reload(sys.modules["nngt"].generation.connectors)
+        reload(sys.modules["nngt"].generation.rewiring)
 
     # set graph-tool config
     _set_gt_config(old_gl, new_config)

--- a/nngt/lib/nngt_config.py
+++ b/nngt/lib/nngt_config.py
@@ -355,10 +355,9 @@ def _post_update_parallelism(new_config, old_gl, old_msd, old_mt, old_mpi):
     new_multithreading = new_config.get("multithreading", old_mt)
 
     if new_multithreading != old_mt:
-        # connectors.py and rewiring.py use directly
-        # nngt.generation.graph_connectivity so they always access the reloaded
-        # version and we don't need to reload them
         reload(sys.modules["nngt"].generation.graph_connectivity)
+        reload(sys.modules["nngt"].generation.connectors)
+        reload(sys.modules["nngt"].generation.rewiring)
 
     # if multithreading loading failed, set omp back to 1
     if not nngt._config['multithreading']:

--- a/nngt/lib/rng_tools.py
+++ b/nngt/lib/rng_tools.py
@@ -88,13 +88,33 @@ def seed(msd=None, seeds=None):
 # ----------------------------- #
 
 def _generate_random(number, instructions):
-    name = instructions[0]
-    if name in di_dfunc:
-        return di_dfunc[name](None, None, number, *instructions[1:])
-    else:
+    name = "not defined"
+
+    if isinstance(instructions, dict):
+        name = instructions["distribution"]
+
+        instructions = {
+            k: v for k, v in instructions.items() if k != "distribution"
+        }
+
+        if name in di_dfunc:
+            return di_dfunc[name](None, None, number, **instructions)
+
         raise NotImplementedError(
             "Unknown distribution: '{}'. Supported distributions " \
             "are {}".format(name, ", ".join(di_dfunc.keys())))
+    elif nonstring_container(instructions):
+        name = instructions[0]
+
+        if name in di_dfunc:
+            return di_dfunc[name](None, None, number, *instructions[1:])
+
+        raise NotImplementedError(
+            "Unknown distribution: '{}'. Supported distributions " \
+            "are {}".format(name, ", ".join(di_dfunc.keys())))
+
+    raise NotImplementedError(
+        "Unknown instructions: '{}'".format(instructions))
 
 
 def _eprop_distribution(graph, distrib_type, matrix=False, elist=None,

--- a/testing/test_attributes.py
+++ b/testing/test_attributes.py
@@ -418,7 +418,6 @@ def test_attributes_are_copied():
 
     assert np.all(np.isclose(vv, g.node_attributes["ntest"]))
     assert not np.all(np.isclose(vv, ntest))
-    
 
 
 # ---------- #

--- a/testing/test_generation2.py
+++ b/testing/test_generation2.py
@@ -436,6 +436,7 @@ def test_connect_switch_distance_rule_max_proba():
     num_omp = nngt.get_config("omp")
     mthread = nngt.get_config("multithreading")
 
+    # switch multithreading to False
     nngt.set_config("multithreading", False)
 
     pop = nngt.NeuralPop.exc_and_inhib(1000)
@@ -464,6 +465,7 @@ def test_connect_switch_distance_rule_max_proba():
     assert 0.75*std < ww.std() < 1.25*std
 
     # restore mt parameters
+    nngt.set_config("mpi", False)
     nngt.set_config("omp", num_omp)
     nngt.set_config("multithreading", mthread)
 

--- a/testing/test_generation2.py
+++ b/testing/test_generation2.py
@@ -438,7 +438,7 @@ def test_connect_switch_distance_rule_max_proba():
 
     nngt.set_config("multithreading", False)
 
-    pop = nngt.NeuralPop.exc_and_inhib(100)
+    pop = nngt.NeuralPop.exc_and_inhib(1000)
 
     radius = 100.
 
@@ -448,11 +448,22 @@ def test_connect_switch_distance_rule_max_proba():
 
     max_proba = 0.1
 
+    avg, std = 10., 1.5
+
+    weights = {"distribution": "gaussian", "avg": avg, "std": std}
+
     ng.connect_nodes(net, pop.inhibitory, pop.excitatory, "distance_rule",
-                     scale=5*radius, max_proba=max_proba)
+                     scale=5*radius, max_proba=max_proba, weights=weights)
 
     assert net.edge_nb() <= len(pop.inhibitory)*len(pop.excitatory)*max_proba
 
+    # check weights
+    ww = net.get_weights()
+
+    assert avg - 0.5*std < ww.mean() < avg + 0.5*std
+    assert 0.75*std < ww.std() < 1.25*std
+
+    # restore mt parameters
     nngt.set_config("omp", num_omp)
     nngt.set_config("multithreading", mthread)
 

--- a/testing/test_generation2.py
+++ b/testing/test_generation2.py
@@ -265,10 +265,23 @@ def test_total_undirected_connectivities():
 
     # erdos-renyi
     density = 0.1
-    g = ng.erdos_renyi(density=density, nodes=num_nodes, directed=False)
+
+    lower, upper = 0.3, 5.4
+
+    weights = {"distribution": "uniform", "lower": lower, "upper": upper}
+
+    g = ng.erdos_renyi(density=density, nodes=num_nodes, directed=False,
+                       weights=weights)
 
     assert g.edge_nb() / (num_nodes*num_nodes) == density
 
+    # check weights
+
+    ww = g.get_weights()
+
+    assert np.all((lower <= ww) * (ww <= upper))
+
+    # check other graph types
     for directed in (True, False):
         # fixed-degree
         deg = 50
@@ -418,6 +431,32 @@ def test_price():
     assert rmin < na.reciprocity(g) < rmax
 
 
+@pytest.mark.mpi_skip
+def test_connect_switch_distance_rule_max_proba():
+    num_omp = nngt.get_config("omp")
+    mthread = nngt.get_config("multithreading")
+
+    nngt.set_config("multithreading", False)
+
+    pop = nngt.NeuralPop.exc_and_inhib(100)
+
+    radius = 100.
+
+    shape = nngt.geometry.Shape.disk(radius)
+
+    net = nngt.SpatialNetwork(population=pop, shape=shape)
+
+    max_proba = 0.1
+
+    ng.connect_nodes(net, pop.inhibitory, pop.excitatory, "distance_rule",
+                     scale=5*radius, max_proba=max_proba)
+
+    assert net.edge_nb() <= len(pop.inhibitory)*len(pop.excitatory)*max_proba
+
+    nngt.set_config("omp", num_omp)
+    nngt.set_config("multithreading", mthread)
+
+
 if __name__ == "__main__":
     if not nngt.get_config("mpi"):
         test_newman_watts()
@@ -427,6 +466,7 @@ if __name__ == "__main__":
         test_all_to_all()
         test_distances()
         test_price()
+        test_connect_switch_distance_rule_max_proba()
 
     if nngt.get_config("mpi"):
         test_mpi_from_degree_list()


### PR DESCRIPTION
This PR fixes #143 (connectivity reload for ``connectors`` and ``rewiring`` when multithreading settings are changed).
It also corrects some bug with the use of ``connect_*`` (missing kwargs).

Finally, it improves support of dict arguments for ``weights/delays`` keywords with connectors.